### PR TITLE
Test framework for the PAB effects

### DIFF
--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -144,7 +144,7 @@ test-suite mlabs-pab-test
   ghc-options:    -fplugin-opt PlutusTx.Plugin:defer-errors
   other-modules:
     Spec.MLabsPAB.Contract
-    Spec.Mock
+    Spec.MockContract
 
   build-depends:
     , aeson                 ^>=1.5.0.0

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -169,6 +169,7 @@ test-suite mlabs-pab-test
     , mlabs-pab
     , neat-interpolation
     , playground-common
+    , plutus-chain-index
     , plutus-contract
     , plutus-core
     , plutus-ledger

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -82,11 +82,11 @@ library
     MLabsPAB.Effects
     MLabsPAB.Files
     MLabsPAB.Types
+    MLabsPAB.UtxoParser
 
   other-modules:
     MLabsPAB.PreBalance
     MLabsPAB.Server
-    MLabsPAB.UtxoParser
 
   build-depends:
     , aeson               ^>=1.5.0.0
@@ -145,6 +145,7 @@ test-suite mlabs-pab-test
   ghc-options:    -fplugin-opt PlutusTx.Plugin:defer-errors
   other-modules:
     Spec.MLabsPAB.Contract
+    Spec.MLabsPAB.UtxoParser
     Spec.MockContract
 
   build-depends:

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -76,6 +76,7 @@ library
   import:          common-lang
   exposed-modules:
     MLabsPAB
+    MLabsPAB.CardanoCLI
     MLabsPAB.ChainIndex
     MLabsPAB.Contract
     MLabsPAB.Effects
@@ -83,7 +84,6 @@ library
     MLabsPAB.Types
 
   other-modules:
-    MLabsPAB.CardanoCLI
     MLabsPAB.PreBalance
     MLabsPAB.Server
     MLabsPAB.UtxoParser

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -76,13 +76,14 @@ library
   import:          common-lang
   exposed-modules:
     MLabsPAB
+    MLabsPAB.ChainIndex
+    MLabsPAB.Contract
     MLabsPAB.Effects
+    MLabsPAB.Files
     MLabsPAB.Types
 
   other-modules:
     MLabsPAB.CardanoCLI
-    MLabsPAB.Contract
-    MLabsPAB.Files
     MLabsPAB.PreBalance
     MLabsPAB.Server
     MLabsPAB.UtxoParser
@@ -141,14 +142,22 @@ test-suite mlabs-pab-test
   type:           exitcode-stdio-1.0
   main-is:        Spec.hs
   ghc-options:    -fplugin-opt PlutusTx.Plugin:defer-errors
+  other-modules:
+    Spec.MLabsPAB.Contract
+    Spec.Mock
+
   build-depends:
     , aeson                 ^>=1.5.0.0
     , attoparsec
     , base
     , base-compat
     , bytestring            ^>=0.10.12.0
+    , cardano-api
+    , cardano-crypto-class
+    , cardano-ledger-core
     , cardano-prelude
     , containers
+    , data-default
     , data-default-class
     , either
     , freer-extras
@@ -156,6 +165,7 @@ test-suite mlabs-pab-test
     , generic-arbitrary
     , lens
     , mlabs-pab
+    , neat-interpolation
     , playground-common
     , plutus-contract
     , plutus-core
@@ -170,10 +180,13 @@ test-suite mlabs-pab-test
     , row-types
     , serialise
     , servant
+    , servant-client
     , servant-server
     , tasty
+    , tasty-hunit
     , tasty-quickcheck
     , text                  ^>=1.2.4.0
+    , uuid
     , vector                ^>=0.12.1.2
     , wai
     , warp

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -76,6 +76,7 @@ library
   import:          common-lang
   exposed-modules:
     MLabsPAB
+    MLabsPAB.Effects
     MLabsPAB.Types
 
   other-modules:

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -161,6 +161,7 @@ test-suite mlabs-pab-test
     , data-default
     , data-default-class
     , either
+    , extra
     , freer-extras
     , freer-simple
     , generic-arbitrary

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -12,6 +12,7 @@ module MLabsPAB.CardanoCLI (
 ) where
 
 import Cardano.Api.Shelley (NetworkId (Mainnet, Testnet), NetworkMagic (..), serialiseAddress)
+import Control.Monad.Freer (Eff, Member)
 import Data.Aeson.Extras (encodeByteString)
 import Data.Attoparsec.Text (parseOnly)
 import Data.Either.Combinators (rightToMaybe)
@@ -43,6 +44,7 @@ import Ledger.Tx (
 import Ledger.TxId (TxId (..))
 import Ledger.Value (Value)
 import Ledger.Value qualified as Value
+import MLabsPAB.Effects (PABEffect, ShellArgs (..), callCommand, uploadDir)
 import MLabsPAB.Files (
   datumJsonFilePath,
   policyScriptFilePath,
@@ -50,51 +52,27 @@ import MLabsPAB.Files (
   signingKeyFilePath,
   validatorScriptFilePath,
  )
-import MLabsPAB.Types (
-  CLILocation (..),
-  PABConfig (..),
- )
+import MLabsPAB.Types (PABConfig)
 import MLabsPAB.UtxoParser qualified as UtxoParser
 import Plutus.Contract.CardanoAPI (toCardanoAddress)
 import Plutus.V1.Ledger.Api (CurrencySymbol (..), TokenName (..))
 import PlutusTx.Builtins (fromBuiltin)
-import System.Process (readProcess)
 import Prelude
 
-data ShellCommand a = ShellCommand
-  { cmdName :: Text
-  , cmdArgs :: [Text]
-  , cmdOutParser :: String -> a
-  }
-
-callCommand :: PABConfig -> ShellCommand a -> IO a
-callCommand PABConfig {pcCliLocation} ShellCommand {cmdName, cmdArgs, cmdOutParser} =
-  case pcCliLocation of
-    Local -> cmdOutParser <$> readProcess (Text.unpack cmdName) (map Text.unpack cmdArgs) ""
-    Remote serverIP ->
-      cmdOutParser
-        <$> readProcess
-          "ssh"
-          (map Text.unpack [serverIP, Text.unwords $ "source ~/.bash_profile;" : cmdName : cmdArgs])
-          ""
-
--- | Upload script files via ssh
-uploadFiles :: PABConfig -> Text -> IO ()
-uploadFiles pabConf serverIP =
+-- | Upload script files to remote server
+uploadFiles :: Member PABEffect effs => PABConfig -> Eff effs ()
+uploadFiles pabConf =
   mapM_
     uploadDir
     [ pabConf.pcScriptFileDir
     , pabConf.pcSigningKeyFileDir
     ]
-  where
-    uploadDir dir = readProcess "scp" ["-r", Text.unpack dir, Text.unpack $ serverIP <> ":$HOME"] ""
 
 -- | Getting all available UTXOs at an address (all utxos are assumed to be PublicKeyChainIndexTxOut)
-utxosAt :: PABConfig -> Address -> IO (Map TxOutRef ChainIndexTxOut)
+utxosAt :: Member PABEffect effs => PABConfig -> Address -> Eff effs (Map TxOutRef ChainIndexTxOut)
 utxosAt pabConf address = do
   callCommand
-    pabConf
-    ShellCommand
+    ShellArgs
       { cmdName = "cardano-cli"
       , cmdArgs =
           mconcat
@@ -110,9 +88,9 @@ utxosAt pabConf address = do
     toUtxo line = parseOnly (UtxoParser.utxoMapParser address) line
 
 -- | Build a tx body and write it to disk
-buildTx :: PABConfig -> PubKey -> Tx -> IO ()
+buildTx :: Member PABEffect effs => PABConfig -> PubKey -> Tx -> Eff effs ()
 buildTx pabConf ownPubKey tx =
-  callCommand pabConf $ ShellCommand "cardano-cli" opts (const ())
+  callCommand $ ShellArgs "cardano-cli" opts (const ())
   where
     ownAddr = Ledger.pubKeyHashAddress $ Ledger.pubKeyHash ownPubKey
     requiredSigners =
@@ -136,10 +114,10 @@ buildTx pabConf ownPubKey tx =
         ]
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
-signTx :: PABConfig -> [PubKey] -> IO ()
+signTx :: Member PABEffect effs => PABConfig -> [PubKey] -> Eff effs ()
 signTx pabConf pubKeys =
-  callCommand pabConf $
-    ShellCommand
+  callCommand $
+    ShellArgs
       "cardano-cli"
       ( mconcat
           [ ["transaction", "sign"]
@@ -156,10 +134,10 @@ signTx pabConf pubKeys =
         pubKeys
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
-submitTx :: PABConfig -> IO (Maybe Text)
+submitTx :: Member PABEffect effs => PABConfig -> Eff effs (Maybe Text)
 submitTx pabConf =
-  callCommand pabConf $
-    ShellCommand
+  callCommand $
+    ShellArgs
       "cardano-cli"
       ( mconcat
           [ ["transaction", "submit"]
@@ -228,7 +206,7 @@ mintOpts pabConf mintingPolicies redeemers mintValue =
     , if not (Value.isZero mintValue)
         then
           [ "--mint"
-          , quotes $ valueToCliArg mintValue
+          , valueToCliArg mintValue
           ]
         else []
     ]
@@ -238,12 +216,11 @@ txOutOpts pabConf =
   concatMap
     ( \TxOut {txOutAddress, txOutValue} ->
         [ "--tx-out"
-        , quotes $
-            Text.intercalate
-              "+"
-              [ unsafeSerialiseAddress pabConf txOutAddress
-              , valueToCliArg txOutValue
-              ]
+        , Text.intercalate
+            "+"
+            [ unsafeSerialiseAddress pabConf txOutAddress
+            , valueToCliArg txOutValue
+            ]
         ]
     )
 
@@ -269,9 +246,6 @@ flatValueToCliArg (curSymbol, name, amount)
 valueToCliArg :: Value -> Text
 valueToCliArg val =
   Text.intercalate " + " $ map flatValueToCliArg $ sort $ Value.flattenValue val
-
-quotes :: Text -> Text
-quotes str = "\"" <> str <> "\""
 
 unsafeSerialiseAddress :: PABConfig -> Address -> Text
 unsafeSerialiseAddress pabConf address =

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -15,12 +15,12 @@ import Cardano.Api.Shelley (NetworkId (Mainnet, Testnet), NetworkMagic (..), ser
 import Control.Monad.Freer (Eff, Member)
 import Data.Aeson.Extras (encodeByteString)
 import Data.Attoparsec.Text (parseOnly)
-import Data.Either.Combinators (rightToMaybe)
+import Data.Either (fromRight)
 import Data.Kind (Type)
 import Data.List (sort)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe, maybeToList)
+import Data.Maybe (maybeToList)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -92,8 +92,7 @@ utxosAt pabConf address = do
             ]
       , cmdOutParser =
           Map.fromList
-            . fromMaybe []
-            . rightToMaybe
+            . fromRight []
             . parseOnly (UtxoParser.utxoMapParser address)
             . Text.pack
       }

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -87,7 +87,7 @@ utxosAt pabConf address = do
       , cmdArgs =
           mconcat
             [ ["query", "utxo"]
-            , ["--address", unsafeSerialiseAddress pabConf address]
+            , ["--address", unsafeSerialiseAddress pabConf.pcNetwork address]
             , networkOpt pabConf
             ]
       , cmdOutParser =
@@ -121,7 +121,7 @@ buildTx pabConf ownPubKey tx =
         , txOutOpts pabConf (txOutputs tx)
         , mintOpts pabConf (txMintScripts tx) (txRedeemers tx) (txMint tx)
         , mconcat
-            [ ["--change-address", unsafeSerialiseAddress pabConf ownAddr]
+            [ ["--change-address", unsafeSerialiseAddress pabConf.pcNetwork ownAddr]
             , requiredSigners
             , networkOpt pabConf
             , ["--protocol-params-file", pabConf.pcProtocolParamsFile]
@@ -243,7 +243,7 @@ txOutOpts pabConf =
         [ "--tx-out"
         , Text.intercalate
             "+"
-            [ unsafeSerialiseAddress pabConf txOutAddress
+            [ unsafeSerialiseAddress pabConf.pcNetwork txOutAddress
             , valueToCliArg txOutValue
             ]
         ]
@@ -272,9 +272,9 @@ valueToCliArg :: Value -> Text
 valueToCliArg val =
   Text.intercalate " + " $ map flatValueToCliArg $ sort $ Value.flattenValue val
 
-unsafeSerialiseAddress :: PABConfig -> Address -> Text
-unsafeSerialiseAddress pabConf address =
-  case serialiseAddress <$> toCardanoAddress pabConf.pcNetwork address of
+unsafeSerialiseAddress :: NetworkId -> Address -> Text
+unsafeSerialiseAddress network address =
+  case serialiseAddress <$> toCardanoAddress network address of
     Right a -> a
     Left _ -> error "Couldn't create address"
 

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -16,6 +16,7 @@ import Control.Monad.Freer (Eff, Member)
 import Data.Aeson.Extras (encodeByteString)
 import Data.Attoparsec.Text (parseOnly)
 import Data.Either.Combinators (rightToMaybe)
+import Data.Kind (Type)
 import Data.List (sort)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -60,7 +61,11 @@ import PlutusTx.Builtins (fromBuiltin)
 import Prelude
 
 -- | Upload script files to remote server
-uploadFiles :: Member PABEffect effs => PABConfig -> Eff effs ()
+uploadFiles ::
+  forall (effs :: [Type -> Type]).
+  Member PABEffect effs =>
+  PABConfig ->
+  Eff effs ()
 uploadFiles pabConf =
   mapM_
     uploadDir
@@ -69,7 +74,12 @@ uploadFiles pabConf =
     ]
 
 -- | Getting all available UTXOs at an address (all utxos are assumed to be PublicKeyChainIndexTxOut)
-utxosAt :: Member PABEffect effs => PABConfig -> Address -> Eff effs (Map TxOutRef ChainIndexTxOut)
+utxosAt ::
+  forall (effs :: [Type -> Type]).
+  Member PABEffect effs =>
+  PABConfig ->
+  Address ->
+  Eff effs (Map TxOutRef ChainIndexTxOut)
 utxosAt pabConf address = do
   callCommand
     ShellArgs
@@ -88,7 +98,13 @@ utxosAt pabConf address = do
     toUtxo line = parseOnly (UtxoParser.utxoMapParser address) line
 
 -- | Build a tx body and write it to disk
-buildTx :: Member PABEffect effs => PABConfig -> PubKey -> Tx -> Eff effs ()
+buildTx ::
+  forall (effs :: [Type -> Type]).
+  Member PABEffect effs =>
+  PABConfig ->
+  PubKey ->
+  Tx ->
+  Eff effs ()
 buildTx pabConf ownPubKey tx =
   callCommand $ ShellArgs "cardano-cli" opts (const ())
   where
@@ -114,7 +130,12 @@ buildTx pabConf ownPubKey tx =
         ]
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
-signTx :: Member PABEffect effs => PABConfig -> [PubKey] -> Eff effs ()
+signTx ::
+  forall (effs :: [Type -> Type]).
+  Member PABEffect effs =>
+  PABConfig ->
+  [PubKey] ->
+  Eff effs ()
 signTx pabConf pubKeys =
   callCommand $
     ShellArgs
@@ -134,7 +155,11 @@ signTx pabConf pubKeys =
         pubKeys
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
-submitTx :: Member PABEffect effs => PABConfig -> Eff effs (Maybe Text)
+submitTx ::
+  forall (effs :: [Type -> Type]).
+  Member PABEffect effs =>
+  PABConfig ->
+  Eff effs (Maybe Text)
 submitTx pabConf =
   callCommand $
     ShellArgs
@@ -253,7 +278,7 @@ unsafeSerialiseAddress pabConf address =
     Right a -> a
     Left _ -> error "Couldn't create address"
 
-showText :: Show a => a -> Text
+showText :: forall (a :: Type). Show a => a -> Text
 showText = Text.pack . show
 
 -- -- TODO: There is some issue with this function, the generated wallet key is incorrect

--- a/src/MLabsPAB/ChainIndex.hs
+++ b/src/MLabsPAB/ChainIndex.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module MLabsPAB.ChainIndex (handleChainIndexReq) where
+
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Network.HTTP.Types (Status (statusCode))
+import Plutus.ChainIndex.Client qualified as ChainIndexClient
+import Plutus.Contract.Effects (ChainIndexQuery (..), ChainIndexResponse (..))
+import Servant.Client (
+  BaseUrl (..),
+  ClientError (FailureResponse),
+  ClientM,
+  ResponseF (Response, responseStatusCode),
+  Scheme (Http),
+  mkClientEnv,
+  runClientM,
+ )
+import Prelude
+
+handleChainIndexReq :: ChainIndexQuery -> IO ChainIndexResponse
+handleChainIndexReq = \case
+  DatumFromHash datumHash ->
+    DatumHashResponse <$> chainIndexQueryOne (ChainIndexClient.getDatum datumHash)
+  ValidatorFromHash validatorHash ->
+    ValidatorHashResponse <$> chainIndexQueryOne (ChainIndexClient.getValidator validatorHash)
+  MintingPolicyFromHash mintingPolicyHash ->
+    MintingPolicyHashResponse
+      <$> chainIndexQueryOne (ChainIndexClient.getMintingPolicy mintingPolicyHash)
+  StakeValidatorFromHash stakeValidatorHash ->
+    StakeValidatorHashResponse
+      <$> chainIndexQueryOne (ChainIndexClient.getStakeValidator stakeValidatorHash)
+  RedeemerFromHash _ ->
+    pure $ RedeemerHashResponse Nothing
+  -- RedeemerFromHash redeemerHash ->
+  --   pure $ RedeemerHashResponse (Maybe Redeemer)
+  TxOutFromRef txOutRef ->
+    TxOutRefResponse <$> chainIndexQueryOne (ChainIndexClient.getTxOut txOutRef)
+  TxFromTxId txId ->
+    TxIdResponse <$> chainIndexQueryOne (ChainIndexClient.getTx txId)
+  UtxoSetMembership txOutRef ->
+    UtxoSetMembershipResponse <$> chainIndexQueryMany (ChainIndexClient.getIsUtxo txOutRef)
+  UtxoSetAtAddress credential -> do
+    UtxoSetAtResponse <$> chainIndexQueryMany (ChainIndexClient.getUtxoAtAddress credential)
+  GetTip ->
+    GetTipResponse <$> chainIndexQueryMany ChainIndexClient.getTip
+
+chainIndexQuery' :: ClientM a -> IO (Either ClientError a)
+chainIndexQuery' endpoint = do
+  manager' <- newManager defaultManagerSettings
+  runClientM endpoint $ mkClientEnv manager' $ BaseUrl Http "localhost" 9083 ""
+
+chainIndexQueryMany :: ClientM a -> IO a
+chainIndexQueryMany endpoint =
+  either (error . show) id <$> chainIndexQuery' endpoint
+
+chainIndexQueryOne :: ClientM a -> IO (Maybe a)
+chainIndexQueryOne endpoint = do
+  res <- chainIndexQuery' endpoint
+  case res of
+    Right result -> pure $ Just result
+    Left failureResp@(FailureResponse _ Response {responseStatusCode})
+      | statusCode responseStatusCode == 404 -> pure Nothing
+      | otherwise -> error (show failureResp)
+    Left failureResp -> error (show failureResp)

--- a/src/MLabsPAB/ChainIndex.hs
+++ b/src/MLabsPAB/ChainIndex.hs
@@ -2,6 +2,7 @@
 
 module MLabsPAB.ChainIndex (handleChainIndexReq) where
 
+import Data.Kind (Type)
 import Network.HTTP.Client (defaultManagerSettings, newManager)
 import Network.HTTP.Types (Status (statusCode))
 import Plutus.ChainIndex.Client qualified as ChainIndexClient
@@ -44,16 +45,16 @@ handleChainIndexReq = \case
   GetTip ->
     GetTipResponse <$> chainIndexQueryMany ChainIndexClient.getTip
 
-chainIndexQuery' :: ClientM a -> IO (Either ClientError a)
+chainIndexQuery' :: forall (a :: Type). ClientM a -> IO (Either ClientError a)
 chainIndexQuery' endpoint = do
   manager' <- newManager defaultManagerSettings
   runClientM endpoint $ mkClientEnv manager' $ BaseUrl Http "localhost" 9083 ""
 
-chainIndexQueryMany :: ClientM a -> IO a
+chainIndexQueryMany :: forall (a :: Type). ClientM a -> IO a
 chainIndexQueryMany endpoint =
   either (error . show) id <$> chainIndexQuery' endpoint
 
-chainIndexQueryOne :: ClientM a -> IO (Maybe a)
+chainIndexQueryOne :: forall (a :: Type). ClientM a -> IO (Maybe a)
 chainIndexQueryOne endpoint = do
   res <- chainIndexQuery' endpoint
   case res of

--- a/src/MLabsPAB/Effects.hs
+++ b/src/MLabsPAB/Effects.hs
@@ -1,0 +1,123 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module MLabsPAB.Effects (
+  createDirectoryIfMissing,
+  chainIndexQuery,
+  listDirectory,
+  threadDelay,
+  uploadDir,
+  printLog,
+  PABEffect (..),
+  ShellArgs (..),
+  handlePABEffect,
+  readFileTextEnvelope,
+  writeFileJSON,
+  writeFileTextEnvelope,
+  callCommand,
+) where
+
+import Cardano.Api (AsType, FileError, HasTextEnvelope, TextEnvelopeDescr, TextEnvelopeError)
+import Cardano.Api qualified
+import Control.Concurrent qualified as Concurrent
+import Control.Monad (void, when)
+import Control.Monad.Freer (Eff, LastMember, interpretM, type (~>))
+import Control.Monad.Freer.TH (makeEffect)
+import Data.Aeson qualified as JSON
+import Data.Text (Text)
+import Data.Text qualified as Text
+import MLabsPAB.Types (CLILocation (..), LogLevel (..), PABConfig (..))
+import Network.HTTP.Client (defaultManagerSettings, newManager)
+import Servant.Client (
+  BaseUrl (..),
+  ClientError,
+  ClientM,
+  Scheme (Http),
+  mkClientEnv,
+  runClientM,
+ )
+import System.Directory qualified as Directory
+import System.Process (readProcess)
+import Prelude hiding (readFile)
+
+data ShellArgs a = ShellArgs
+  { cmdName :: Text
+  , cmdArgs :: [Text]
+  , cmdOutParser :: String -> a
+  }
+
+instance Show (ShellArgs a) where
+  show ShellArgs {cmdName, cmdArgs} = Text.unpack $ cmdName <> mconcat cmdArgs
+
+data PABEffect r where
+  CallCommand :: ShellArgs a -> PABEffect a
+  CreateDirectoryIfMissing :: Bool -> FilePath -> PABEffect ()
+  PrintLog :: LogLevel -> String -> PABEffect ()
+  ThreadDelay :: Int -> PABEffect ()
+  ReadFileTextEnvelope ::
+    HasTextEnvelope a =>
+    AsType a ->
+    FilePath ->
+    PABEffect (Either (FileError TextEnvelopeError) a)
+  WriteFileJSON :: FilePath -> JSON.Value -> PABEffect (Either (FileError ()) ())
+  WriteFileTextEnvelope ::
+    HasTextEnvelope a =>
+    FilePath ->
+    Maybe TextEnvelopeDescr ->
+    a ->
+    PABEffect (Either (FileError ()) ())
+  ListDirectory :: FilePath -> PABEffect [FilePath]
+  UploadDir :: Text -> PABEffect ()
+  ChainIndexQuery :: ClientM a -> PABEffect (Either ClientError a)
+
+handlePABEffect :: forall effs. (LastMember IO effs) => PABConfig -> Eff (PABEffect ': effs) ~> Eff effs
+handlePABEffect pabConf =
+  interpretM
+    ( \case
+        CallCommand shellArgs ->
+          case pabConf.pcCliLocation of
+            Local -> callLocalCommand shellArgs
+            Remote ipAddr -> callRemoteCommand ipAddr shellArgs
+        CreateDirectoryIfMissing createParents filePath ->
+          Directory.createDirectoryIfMissing createParents filePath
+        PrintLog logLevel txt -> printLog' pabConf.pcLogLevel logLevel txt
+        ThreadDelay microSeconds -> Concurrent.threadDelay microSeconds
+        ReadFileTextEnvelope asType filepath -> Cardano.Api.readFileTextEnvelope asType filepath
+        WriteFileJSON filepath value -> Cardano.Api.writeFileJSON filepath value
+        WriteFileTextEnvelope filepath envelopeDescr contents ->
+          Cardano.Api.writeFileTextEnvelope filepath envelopeDescr contents
+        ListDirectory filepath -> Directory.listDirectory filepath
+        UploadDir dir ->
+          case pabConf.pcCliLocation of
+            Local -> pure ()
+            Remote ipAddr ->
+              void $ readProcess "scp" ["-r", Text.unpack dir, Text.unpack $ ipAddr <> ":$HOME"] ""
+        ChainIndexQuery endpoint ->
+          chainIndexQuery' endpoint
+    )
+
+printLog' :: LogLevel -> LogLevel -> String -> IO ()
+printLog' logLevelSetting msgLogLvl msg =
+  when (logLevelSetting >= msgLogLvl) $ putStrLn msg
+
+callLocalCommand :: ShellArgs a -> IO a
+callLocalCommand ShellArgs {cmdName, cmdArgs, cmdOutParser} =
+  cmdOutParser <$> readProcess (Text.unpack cmdName) (map Text.unpack cmdArgs) ""
+
+callRemoteCommand :: Text -> ShellArgs a -> IO a
+callRemoteCommand ipAddr ShellArgs {cmdName, cmdArgs, cmdOutParser} =
+  cmdOutParser
+    <$> readProcess
+      "ssh"
+      (map Text.unpack [ipAddr, Text.unwords $ "source ~/.bash_profile;" : cmdName : map quotes cmdArgs])
+      ""
+quotes :: Text -> Text
+quotes str = "\"" <> str <> "\""
+
+chainIndexQuery' :: ClientM a -> IO (Either ClientError a)
+chainIndexQuery' endpoint = do
+  manager' <- newManager defaultManagerSettings
+  runClientM endpoint $ mkClientEnv manager' $ BaseUrl Http "localhost" 9083 ""
+
+makeEffect ''PABEffect

--- a/src/MLabsPAB/Files.hs
+++ b/src/MLabsPAB/Files.hs
@@ -19,10 +19,7 @@ import Cardano.Api (
   PaymentKey,
   SigningKey,
   getVerificationKey,
-  readFileTextEnvelope,
   serialiseToRawBytes,
-  writeFileJSON,
-  writeFileTextEnvelope,
  )
 import Cardano.Api.Shelley (
   PlutusScript (PlutusScriptSerialised),
@@ -33,6 +30,7 @@ import Cardano.Api.Shelley (
  )
 import Cardano.Crypto.Wallet qualified as Crypto
 import Codec.Serialise qualified as Codec
+import Control.Monad.Freer (Eff, Member)
 import Data.Aeson qualified as JSON
 import Data.Aeson.Extras (encodeByteString)
 import Data.ByteString qualified as ByteString
@@ -46,6 +44,13 @@ import Data.Text qualified as Text
 import Ledger qualified
 import Ledger.Crypto (PrivateKey, PubKeyHash (PubKeyHash))
 import Ledger.Value qualified as Value
+import MLabsPAB.Effects (
+  PABEffect,
+  listDirectory,
+  readFileTextEnvelope,
+  writeFileJSON,
+  writeFileTextEnvelope,
+ )
 import MLabsPAB.Types (PABConfig)
 import Plutus.V1.Ledger.Api (
   CurrencySymbol,
@@ -60,7 +65,6 @@ import Plutus.V1.Ledger.Api (
  )
 import PlutusTx (ToData, toData)
 import PlutusTx.Builtins (fromBuiltin)
-import System.Directory (listDirectory)
 import Prelude
 
 -- | Filename of a minting policy script
@@ -91,36 +95,47 @@ signingKeyFilePath pabConf (PubKeyHash pubKeyHash) =
    in pabConf.pcSigningKeyFileDir <> "/signing-key-" <> h <> ".skey"
 
 -- | Compiles and writes a script file under the given folder
-writePolicyScriptFile :: PABConfig -> MintingPolicy -> IO (Either (FileError ()) Text)
+writePolicyScriptFile :: Member PABEffect effs => PABConfig -> MintingPolicy -> Eff effs (Either (FileError ()) Text)
 writePolicyScriptFile pabConf mintingPolicy =
   let script = serialiseScript $ Ledger.unMintingPolicyScript mintingPolicy
       filepath = policyScriptFilePath pabConf (Ledger.scriptCurrencySymbol mintingPolicy)
    in fmap (const filepath) <$> writeFileTextEnvelope (Text.unpack filepath) Nothing script
 
 -- | Compiles and writes a script file under the given folder
-writeValidatorScriptFile :: PABConfig -> Validator -> IO (Either (FileError ()) Text)
+writeValidatorScriptFile ::
+  Member PABEffect effs =>
+  PABConfig ->
+  Validator ->
+  Eff effs (Either (FileError ()) Text)
 writeValidatorScriptFile pabConf validatorScript =
   let script = serialiseScript $ Ledger.unValidatorScript validatorScript
       filepath = validatorScriptFilePath pabConf (Ledger.validatorHash validatorScript)
    in fmap (const filepath) <$> writeFileTextEnvelope (Text.unpack filepath) Nothing script
 
 writeAll ::
+  Member PABEffect effs =>
   PABConfig ->
   [MintingPolicy] ->
   [Validator] ->
   [Datum] ->
   [Redeemer] ->
-  IO (Either (FileError ()) [Text])
-writeAll pabConf policyScripts validatorScripts datums redeemers =
-  sequence
-    <$> mconcat
-      [ mapM (writePolicyScriptFile pabConf) policyScripts
-      , mapM (writeValidatorScriptFile pabConf) validatorScripts
-      , mapM (writeDatumJsonFile pabConf) datums
-      , mapM (writeRedeemerJsonFile pabConf) redeemers
-      ]
+  Eff effs (Either (FileError ()) [Text])
+writeAll pabConf policyScripts validatorScripts datums redeemers = do
+  results <-
+    sequence $
+      mconcat
+        [ map (writePolicyScriptFile pabConf) policyScripts
+        , map (writeValidatorScriptFile pabConf) validatorScripts
+        , map (writeDatumJsonFile pabConf) datums
+        , map (writeRedeemerJsonFile pabConf) redeemers
+        ]
 
-readPrivateKeys :: PABConfig -> IO (Either Text (Map PubKeyHash PrivateKey))
+  pure $ sequence results
+
+readPrivateKeys ::
+  Member PABEffect effs =>
+  PABConfig ->
+  Eff effs (Either Text (Map PubKeyHash PrivateKey))
 readPrivateKeys pabConf = do
   files <- listDirectory $ Text.unpack pabConf.pcSigningKeyFileDir
   let sKeyFiles =
@@ -138,7 +153,7 @@ readPrivateKeys pabConf = do
         )
         Map.empty
 
-readPrivateKey :: FilePath -> IO (Either Text PrivateKey)
+readPrivateKey :: Member PABEffect effs => FilePath -> Eff effs (Either Text PrivateKey)
 readPrivateKey filePath = do
   pKey <- mapLeft (Text.pack . show) <$> readFileTextEnvelope (AsSigningKey AsPaymentKey) filePath
   pure $ fromCardanoPaymentKey =<< pKey
@@ -172,13 +187,21 @@ serialiseScript =
     . LazyByteString.toStrict
     . Codec.serialise
 
-writeDatumJsonFile :: PABConfig -> Datum -> IO (Either (FileError ()) Text)
+writeDatumJsonFile ::
+  Member PABEffect effs =>
+  PABConfig ->
+  Datum ->
+  Eff effs (Either (FileError ()) Text)
 writeDatumJsonFile pabConf datum =
   let json = dataToJson $ getDatum datum
       filepath = datumJsonFilePath pabConf (Ledger.datumHash datum)
    in fmap (const filepath) <$> writeFileJSON (Text.unpack filepath) json
 
-writeRedeemerJsonFile :: PABConfig -> Redeemer -> IO (Either (FileError ()) Text)
+writeRedeemerJsonFile ::
+  Member PABEffect effs =>
+  PABConfig ->
+  Redeemer ->
+  Eff effs (Either (FileError ()) Text)
 writeRedeemerJsonFile pabConf redeemer =
   let json = dataToJson $ getRedeemer redeemer
       filepath = redeemerJsonFilePath pabConf (Ledger.redeemerHash redeemer)

--- a/src/MLabsPAB/Files.hs
+++ b/src/MLabsPAB/Files.hs
@@ -10,6 +10,7 @@ module MLabsPAB.Files (
   writeRedeemerJsonFile,
   writeValidatorScriptFile,
   datumJsonFilePath,
+  fromCardanoPaymentKey,
   writeDatumJsonFile,
 ) where
 

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -4,6 +4,7 @@ module MLabsPAB.PreBalance (
 
 import Control.Monad (foldM)
 import Data.Either.Combinators (rightToMaybe)
+import Data.Kind (Type)
 import Data.List (partition)
 import Data.Map (Map)
 import Data.Map qualified as Map
@@ -174,7 +175,7 @@ addSignatories ownPkh privKeys pkhs tx =
     tx
     (ownPkh : pkhs)
 
-showText :: Show a => a -> Text
+showText :: forall (a :: Type). Show a => a -> Text
 showText = Text.pack . show
 
 -- | Filter a value to contain only non ada assets

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -25,13 +25,14 @@ import Ledger.Tx (
   TxOutRef (..),
  )
 import Ledger.Tx qualified as Tx
-import Ledger.Value (Value)
+import Ledger.Value (Value (Value), getValue)
 import Ledger.Value qualified as Value
 import Plutus.V1.Ledger.Api (
   Credential (PubKeyCredential, ScriptCredential),
   CurrencySymbol (..),
   TokenName (..),
  )
+import PlutusTx.AssocMap qualified as AssocMap
 import Prelude
 
 {- | Collect necessary tx inputs and collaterals, add minimum lovelace values and balance non ada
@@ -180,13 +181,13 @@ addSignatories ownPkh privKeys pkhs tx =
 showText :: forall (a :: Type). Show a => a -> Text
 showText = Text.pack . show
 
+-- | Filter by key for Associated maps (why doesn't this exist?)
+filterKey :: (k -> Bool) -> AssocMap.Map k v -> AssocMap.Map k v
+filterKey f = AssocMap.mapMaybeWithKey $ \k v -> if f k then Just v else Nothing
+
 -- | Filter a value to contain only non ada assets
 filterNonAda :: Value -> Value
-filterNonAda =
-  mconcat
-    . map unflattenValue
-    . filter (\(curSymbol, tokenName, _) -> curSymbol /= Ada.adaSymbol && tokenName /= Ada.adaToken)
-    . Value.flattenValue
+filterNonAda = Value . filterKey (/= Ada.adaSymbol) . getValue
 
 minus :: Value -> Value -> Value
 minus x y =

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -49,8 +49,8 @@ preBalanceTx ::
 preBalanceTx minLovelaces fees utxos ownPkh privKeys requiredSignatories tx =
   addTxCollaterals utxos tx
     >>= balanceTxIns utxos minLovelaces fees
-    >>= Right . addLovelaces minLovelaces
     >>= balanceNonAdaOuts ownPkh utxos
+    >>= Right . addLovelaces minLovelaces
     >>= addSignatories ownPkh privKeys requiredSignatories
 
 -- | Getting the necessary utxos to cover the fees for the transaction
@@ -149,7 +149,7 @@ balanceNonAdaOuts ownPkh utxos tx =
       nonMintedOutputValue = outputValue `minus` txMint tx
       nonAdaChange = filterNonAda inputValue `minus` filterNonAda nonMintedOutputValue
       outputs =
-        case partition ((/=) changeAddr . Tx.txOutAddress) $ txOutputs tx of
+        case partition ((==) changeAddr . Tx.txOutAddress) $ txOutputs tx of
           ([], txOuts) ->
             TxOut
               { txOutAddress = changeAddr
@@ -159,7 +159,9 @@ balanceNonAdaOuts ownPkh utxos tx =
             txOuts
           (txOut@TxOut {txOutValue = v} : txOuts, txOuts') ->
             txOut {txOutValue = v <> nonAdaChange} : (txOuts <> txOuts')
-   in Right $ tx {txOutputs = outputs}
+   in if Value.isZero nonAdaChange
+        then Right tx
+        else Right $ tx {txOutputs = outputs}
 
 {- | Add the required signatorioes to the transaction. Be aware the the signature itself is invalid,
  and will be ignored. Only the pub key hashes are used, mapped to signing key files on disk.

--- a/src/MLabsPAB/Types.hs
+++ b/src/MLabsPAB/Types.hs
@@ -41,6 +41,7 @@ data PABConfig = PABConfig
     pcDryRun :: !Bool
   , pcLogLevel :: !LogLevel
   }
+  deriving stock (Show, Eq)
 
 data ContractEnvironment = ContractEnvironment
   { cePABConfig :: PABConfig
@@ -48,13 +49,15 @@ data ContractEnvironment = ContractEnvironment
   , ceWallet :: Wallet
   , -- | TODO: We should get this from the wallet, once the integration works
     ceOwnPubKey :: PubKey
-  , -- | TODO: We should be able acalculate this
+  , -- | TODO: We should be able to calculate this
     ceFees :: Integer
-  , -- | TODO: We should be able acalculate this
+  , -- | TODO: We should be able to calculate this
     ceMinLovelaces :: Integer
   }
+  deriving stock (Show, Eq)
 
 data CLILocation = Local | Remote Text
+  deriving stock (Show, Eq)
 
 data LogLevel = Error | Warn | Notice | Info | Debug
   deriving stock (Eq, Ord, Show)

--- a/src/MLabsPAB/Types.hs
+++ b/src/MLabsPAB/Types.hs
@@ -1,6 +1,7 @@
 module MLabsPAB.Types (
   PABConfig (..),
   CLILocation (..),
+  LogLevel (..),
   ContractEnvironment (..),
   HasDefinitions (..),
   FormSchema,
@@ -38,6 +39,7 @@ data PABConfig = PABConfig
     pcProtocolParamsFile :: !Text
   , -- | Dry run mode will build the tx, but skip the submit step
     pcDryRun :: !Bool
+  , pcLogLevel :: !LogLevel
   }
 
 data ContractEnvironment = ContractEnvironment
@@ -54,6 +56,9 @@ data ContractEnvironment = ContractEnvironment
 
 data CLILocation = Local | Remote Text
 
+data LogLevel = Error | Warn | Notice | Info | Debug
+  deriving stock (Eq, Ord, Show)
+
 instance Default PABConfig where
   def =
     PABConfig
@@ -64,4 +69,5 @@ instance Default PABConfig where
       , pcSigningKeyFileDir = "signing-keys"
       , pcDryRun = True
       , pcProtocolParamsFile = "./protocol.json"
+      , pcLogLevel = Info
       }

--- a/src/MLabsPAB/UtxoParser.hs
+++ b/src/MLabsPAB/UtxoParser.hs
@@ -53,7 +53,7 @@ skipLine n =
   void $
     count n $ do
       skipWhile (not . isEndOfLine)
-      skipWhile $ inClass "\r\n"
+      skipWhile isEndOfLine
 
 utxoParser :: Address -> Parser (TxOutRef, ChainIndexTxOut)
 utxoParser address =

--- a/src/MLabsPAB/UtxoParser.hs
+++ b/src/MLabsPAB/UtxoParser.hs
@@ -1,19 +1,25 @@
 module MLabsPAB.UtxoParser (
   chainIndexTxOutParser,
+  utxoParser,
   utxoMapParser,
 ) where
 
-import Control.Monad (mzero, void)
+import Control.Applicative (many)
+import Control.Monad (forM_, mzero, void)
 import Data.Aeson.Extras (tryDecode)
 import Data.Attoparsec.Text (
   Parser,
   char,
   choice,
   decimal,
+  inClass,
+  option,
   sepBy,
   signed,
   skipSpace,
+  skipWhile,
   takeWhile,
+  (<?>),
  )
 import Data.Text (Text)
 import Data.Text.Encoding (encodeUtf8)
@@ -25,7 +31,7 @@ import Ledger.Tx (
   TxOutRef (..),
  )
 import Ledger.TxId (TxId (..))
-import Ledger.Value (AssetClass, Value)
+import Ledger.Value (AssetClass, TokenName, Value)
 import Ledger.Value qualified as Value
 import Plutus.V1.Ledger.Api (
   BuiltinByteString,
@@ -35,9 +41,21 @@ import Plutus.V1.Ledger.Api (
 import PlutusTx.Builtins (toBuiltin)
 import Prelude hiding (takeWhile)
 
-utxoMapParser :: Address -> Parser (TxOutRef, ChainIndexTxOut)
-utxoMapParser address =
-  (,) <$> txOutRefParser <* skipSpace <*> chainIndexTxOutParser address
+utxoMapParser :: Address -> Parser [(TxOutRef, ChainIndexTxOut)]
+utxoMapParser address = do
+  skipLine 2
+  many (utxoParser address)
+
+skipLine :: Int -> Parser ()
+skipLine n =
+  forM_ [1 .. n] $ \_ -> do
+    skipWhile (not . inClass "\r\n")
+    skipWhile $ inClass "\r\n"
+
+utxoParser :: Address -> Parser (TxOutRef, ChainIndexTxOut)
+utxoParser address =
+  (,) <$> (txOutRefParser <?> "TxOutRef") <* skipSpace
+    <*> (chainIndexTxOutParser address <?> "ChainIndexTxOut") <* skipWhile (inClass "\r\n")
 
 txOutRefParser :: Parser TxOutRef
 txOutRefParser = do
@@ -49,22 +67,22 @@ txOutRefParser = do
 
 chainIndexTxOutParser :: Address -> Parser ChainIndexTxOut
 chainIndexTxOutParser address = do
-  value <- mconcat <$> valueParser `sepBy` " + "
+  value <- mconcat <$> (valueParser <?> "Value") `sepBy` " + "
   void " + "
 
   case addressCredential address of
     ScriptCredential validatorHash -> do
-      datumHash <- datumHashParser
+      datumHash <- datumHashParser <?> "DatumHash"
       pure $ ScriptChainIndexTxOut address (Left validatorHash) (Left datumHash) value
     PubKeyCredential _ -> do
-      datumHashNoneParser
+      datumHashNoneParser <?> "DatumHash"
       pure $ PublicKeyChainIndexTxOut address value
 
 valueParser :: Parser Value
 valueParser = do
   amt <- signed decimal
   skipSpace
-  assetClass <- assetClassParser
+  assetClass <- assetClassParser <?> "AssetClass"
   pure $ Value.assetClassValue assetClass amt
 
 assetClassParser :: Parser AssetClass
@@ -73,10 +91,17 @@ assetClassParser =
   where
     adaAssetClass = Value.assetClass Ada.adaSymbol Ada.adaToken <$ "lovelace"
     otherAssetClass = do
-      curSymbol <- CurrencySymbol <$> decodeHash (takeWhile (/= '.'))
+      curSymbol <- CurrencySymbol <$> decodeHash (takeWhile (not . inClass " .")) <?> "CurrencySymbol"
+      tokenname <- tokenNameParser <?> "TokenName"
+      pure $ Value.assetClass curSymbol tokenname
+
+tokenNameParser :: Parser TokenName
+tokenNameParser = do
+  option "" tokenName
+  where
+    tokenName = do
       void $ char '.'
-      tokenName <- Value.tokenName . encodeUtf8 <$> takeWhile (/= ' ')
-      pure $ Value.assetClass curSymbol tokenName
+      Value.tokenName . encodeUtf8 <$> takeWhile (/= ' ')
 
 datumHashNoneParser :: Parser ()
 datumHashNoneParser = "TxOutDatumNone" >> pure ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
-import Spec.MLabsPAB.Contract qualified as MLabsPAB.Contract
+import Spec.MLabsPAB.Contract qualified
+import Spec.MLabsPAB.UtxoParser qualified
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Prelude
 
@@ -16,4 +17,6 @@ tests :: TestTree
 tests =
   testGroup
     "MLabsPAB"
-    [MLabsPAB.Contract.tests]
+    [ Spec.MLabsPAB.Contract.tests
+    , Spec.MLabsPAB.UtxoParser.tests
+    ]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,7 +1,8 @@
 module Main (main) where
 
-import Test.Tasty
-import Prelude (IO)
+import Spec.MLabsPAB.Contract qualified as MLabsPAB.Contract
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Prelude
 
 -- | @since 0.1
 main :: IO ()
@@ -14,5 +15,5 @@ main = defaultMain tests
 tests :: TestTree
 tests =
   testGroup
-    "HackPAB"
-    []
+    "MLabsPAB"
+    [MLabsPAB.Contract.tests]

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -12,6 +12,7 @@ import Data.Text qualified as Text
 import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
+import Ledger.Value qualified as Value
 import NeatInterpolation (text)
 import Plutus.Contract (Contract (..), Endpoint, submitTx)
 import Spec.MockContract (MockConfig (..), pubKey2, pubKey3, runContractPure)
@@ -29,6 +30,7 @@ tests =
     "MLabsPAB.Contracts"
     [ testCase "Send ada to address" sendAda
     , testCase "Support multiple signatories" multisigSupport
+    , testCase "Support native tokens" sendTokens
     ]
 
 sendAda :: Assertion
@@ -39,7 +41,7 @@ sendAda = do
               ("cardano-cli", "query" : "utxo" : _) ->
                 pure $
                   queryUtxoOut
-                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250)]
+                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250, [])]
               ("cardano-cli", "transaction" : "build" : _) ->
                 pure ""
               ("cardano-cli", "transaction" : "sign" : _) ->
@@ -82,7 +84,7 @@ multisigSupport = do
               ("cardano-cli", "query" : "utxo" : _) ->
                 pure $
                   queryUtxoOut
-                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250)]
+                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250, [])]
               ("cardano-cli", "transaction" : "build" : _) ->
                 pure ""
               ("cardano-cli", "transaction" : "sign" : _) ->
@@ -121,7 +123,59 @@ multisigSupport = do
           \--out-file tx.signed"
         ]
 
-queryUtxoOut :: [(Text, Int, Int)] -> String
+sendTokens :: Assertion
+sendTokens = do
+  let mockConfig =
+        MockConfig
+          { handleCliCommand = \case
+              ("cardano-cli", "query" : "utxo" : _) ->
+                pure $
+                  queryUtxoOut
+                    [
+                      ( "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5"
+                      , 0
+                      , 1250
+                      , [("abcd1234.testToken", 100)]
+                      )
+                    ]
+              ("cardano-cli", "transaction" : "build" : _) ->
+                pure ""
+              ("cardano-cli", "transaction" : "sign" : _) ->
+                pure ""
+              ("cardano-cli", "transaction" : "submit" : _) ->
+                pure ""
+              _ -> throwError @Text ""
+          }
+
+      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract = do
+        let constraints =
+              Constraints.mustPayToPubKey
+                (Ledger.pubKeyHash pubKey2)
+                (Ada.lovelaceValueOf 1000 <> Value.singleton "abcd1234" "testToken" 5)
+        void $ submitTx constraints
+
+      (result, state) = runContractPure contract mockConfig def
+  result @?= Right ()
+  state.commandHistory
+    @?= [ "cardano-cli query utxo \
+          \--address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+          \--testnet-magic 42"
+        , "cardano-cli transaction build --alonzo-era \
+          \--tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+          \--tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+          \--tx-out addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35+50 + 95 abcd1234.testToken \
+          \--tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 + 5 abcd1234.testToken \
+          \--change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+          \--required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+          \--testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw"
+        , "cardano-cli transaction sign \
+          \--tx-body-file tx.raw \
+          \--signing-key-file signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+          \--out-file tx.signed"
+        ]
+
+queryUtxoOut :: [(Text, Int, Int, [(Text, Int)])] -> String
 queryUtxoOut utxos =
   Text.unpack $
     Text.unlines
@@ -129,10 +183,15 @@ queryUtxoOut utxos =
       , "--------------------------------------------------------------------------------------"
       , Text.unlines $
           map
-            ( \(txId, txIx, amt) ->
+            ( \(txId, txIx, amt, tokens) ->
                 let txIx' = Text.pack $ show txIx
-                    amt' = Text.pack $ show amt
-                 in [text|${txId}     ${txIx'}        ${amt'} lovelace + TxOutDatumNone"|]
+                    amts =
+                      Text.intercalate
+                        " + "
+                        ( Text.pack (show amt) <> " " <> "lovelace" :
+                          map (\(tSymbol, tAmt) -> Text.pack (show tAmt) <> " " <> tSymbol) tokens
+                        )
+                 in [text|${txId}     ${txIx'}        ${amts} + TxOutDatumNone"|]
             )
             utxos
       ]

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Spec.MLabsPAB.Contract (tests) where
+
+import Control.Monad (void)
+import Control.Monad.Freer.Error (throwError)
+import Data.Default (def)
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Ledger qualified
+import Ledger.Ada qualified as Ada
+import Ledger.Constraints qualified as Constraints
+import NeatInterpolation (text)
+import Plutus.Contract (Contract (..), ContractError, Endpoint, submitTx)
+import Spec.Mock (MockConfig (..), pubKey2, runContractPure)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@=?))
+import Prelude
+
+{- | Project wide tests
+
+ @since 0.1
+-}
+tests :: TestTree
+tests =
+  testGroup
+    "MLabsPAB.Contracts"
+    [testCase "Send ada to address" sendAda]
+
+sendAda :: Assertion
+sendAda =
+  let mockConfig =
+        MockConfig
+          { handleCliCommand = \case
+              ("cardano-cli", "query" : "utxo" : _) ->
+                pure $
+                  queryUtxoOut
+                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250)]
+              ("cardano-cli", "transaction" : "build" : _) ->
+                pure ""
+              ("cardano-cli", "transaction" : "sign" : _) ->
+                pure ""
+              ("cardano-cli", "transaction" : "submit" : _) ->
+                pure ""
+              _ -> throwError ()
+          }
+
+      contract :: Contract () (Endpoint "SendAda" ()) ContractError ()
+      contract = do
+        let constraints =
+              Constraints.mustPayToPubKey (Ledger.pubKeyHash pubKey2) (Ada.lovelaceValueOf 1000)
+        void $ submitTx constraints
+
+      contractResult = runContractPure contract mockConfig def
+   in [ "cardano-cli query utxo \
+        \--address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+        \--testnet-magic 42"
+      , "cardano-cli transaction build --alonzo-era \
+        \--tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+        \--tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+        \--tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 \
+        \--change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+        \--required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+        \--testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw"
+      , "cardano-cli transaction sign \
+        \--tx-body-file tx.raw \
+        \--signing-key-file signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+        \--out-file tx.signed"
+      ]
+        @=? reverse contractResult.commandHistory
+
+queryUtxoOut :: [(Text, Int, Int)] -> String
+queryUtxoOut utxos =
+  Text.unpack $
+    Text.unlines
+      [ "                           TxHash                                 TxIx        Amount"
+      , "--------------------------------------------------------------------------------------"
+      , Text.unlines $
+          map
+            ( \(txId, txIx, amt) ->
+                let txIx' = Text.pack $ show txIx
+                    amt' = Text.pack $ show amt
+                 in [text|${txId}     ${txIx'}        ${amt'} lovelace + TxOutDatumNone"|]
+            )
+            utxos
+      ]

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -1,16 +1,25 @@
 {-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Spec.MLabsPAB.Contract (tests) where
 
 import Control.Monad (void)
+import Data.Aeson.Extras (encodeByteString)
 import Data.Default (def)
 import Data.Function ((&))
 import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Void (Void)
 import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
+import Ledger.Scripts qualified as Scripts
 import Ledger.Value qualified as Value
-import Plutus.Contract (Contract (..), Endpoint, submitTx)
+import NeatInterpolation (text)
+import Plutus.Contract (Contract (..), Endpoint, submitTx, submitTxConstraintsWith)
+import PlutusTx qualified
+import PlutusTx.Builtins (fromBuiltin)
 import Spec.MockContract (pubKey2, pubKey3, runContractPure, withUtxos)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@?=))
@@ -26,7 +35,8 @@ tests =
     "MLabsPAB.Contracts"
     [ testCase "Send ada to address" sendAda
     , testCase "Support multiple signatories" multisigSupport
-    , testCase "Support native tokens" sendTokens
+    , testCase "Send native tokens" sendTokens
+    , testCase "Mint native tokens" mintTokens
     ]
 
 sendAda :: Assertion
@@ -118,11 +128,63 @@ sendTokens = do
       (result, state) = runContractPure contract mockConfig def
   result @?= Right ()
   (state.commandHistory !! 1)
-    @?= "cardano-cli transaction build --alonzo-era \
-        \--tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
-        \--tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
-        \--tx-out addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35+50 + 95 abcd1234.testToken \
-        \--tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 + 5 abcd1234.testToken \
-        \--change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
-        \--required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
-        \--testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw"
+    @?= Text.replace
+      "\n"
+      " "
+      [text|
+        cardano-cli transaction build --alonzo-era
+        --tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0
+        --tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0
+        --tx-out addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35+50 + 95 abcd1234.testToken
+        --tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 + 5 abcd1234.testToken
+        --change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35
+        --required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey
+        --testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw
+      |]
+
+mintTokens :: Assertion
+mintTokens = do
+  let mockConfig =
+        def
+          & withUtxos
+            [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250, [])]
+
+      mintingPolicy :: Scripts.MintingPolicy
+      mintingPolicy =
+        Scripts.mkMintingPolicyScript
+          $$(PlutusTx.compile [||(\_ _ -> ())||])
+
+      curSymbol :: Value.CurrencySymbol
+      curSymbol = Ledger.scriptCurrencySymbol mintingPolicy
+
+      curSymbol' :: Text
+      curSymbol' = encodeByteString $ fromBuiltin $ Value.unCurrencySymbol curSymbol
+
+      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract = do
+        let lookups =
+              Constraints.mintingPolicy mintingPolicy
+        let constraints =
+              Constraints.mustMintValue (Value.singleton curSymbol "testToken" 5)
+                <> Constraints.mustPayToPubKey
+                  (Ledger.pubKeyHash pubKey2)
+                  (Ada.lovelaceValueOf 1000 <> Value.singleton curSymbol "testToken" 5)
+        void $ submitTxConstraintsWith @Void lookups constraints
+
+      (result, state) = runContractPure contract mockConfig def
+  result @?= Right ()
+  (state.commandHistory !! 1)
+    @?= Text.replace
+      "\n"
+      " "
+      [text| cardano-cli transaction build --alonzo-era
+       --tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0
+       --tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0
+       --tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 + 5 ${curSymbol'}.testToken
+       --mint-script-file result-scripts/policy-${curSymbol'}.plutus
+       --mint-redeemer-file result-scripts/redeemer-923918e403bf43c34b4ef6b48eb2ee04babed17320d8d1b9ff9ad086e86f44ec.json
+       --mint 5 ${curSymbol'}.testToken
+       --change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35
+       --required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey
+       --testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw
+      |]

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -14,7 +14,7 @@ import Ledger.Ada qualified as Ada
 import Ledger.Constraints qualified as Constraints
 import NeatInterpolation (text)
 import Plutus.Contract (Contract (..), ContractError, Endpoint, submitTx)
-import Spec.Mock (MockConfig (..), pubKey2, runContractPure)
+import Spec.MockContract (MockConfig (..), pubKey2, pubKey3, runContractPure)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, testCase, (@=?))
 import Prelude
@@ -27,7 +27,9 @@ tests :: TestTree
 tests =
   testGroup
     "MLabsPAB.Contracts"
-    [testCase "Send ada to address" sendAda]
+    [ testCase "Send ada to address" sendAda
+    , testCase "Support multiple signatories" multisigSupport
+    ]
 
 sendAda :: Assertion
 sendAda =
@@ -67,6 +69,52 @@ sendAda =
       , "cardano-cli transaction sign \
         \--tx-body-file tx.raw \
         \--signing-key-file signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+        \--out-file tx.signed"
+      ]
+        @=? reverse contractResult.commandHistory
+
+multisigSupport :: Assertion
+multisigSupport =
+  let mockConfig =
+        MockConfig
+          { handleCliCommand = \case
+              ("cardano-cli", "query" : "utxo" : _) ->
+                pure $
+                  queryUtxoOut
+                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250)]
+              ("cardano-cli", "transaction" : "build" : _) ->
+                pure ""
+              ("cardano-cli", "transaction" : "sign" : _) ->
+                pure ""
+              ("cardano-cli", "transaction" : "submit" : _) ->
+                pure ""
+              _ -> throwError ()
+          }
+
+      contract :: Contract () (Endpoint "SendAda" ()) ContractError ()
+      contract = do
+        let constraints =
+              Constraints.mustPayToPubKey (Ledger.pubKeyHash pubKey2) (Ada.lovelaceValueOf 1000)
+                <> Constraints.mustBeSignedBy (Ledger.pubKeyHash pubKey3)
+        void $ submitTx constraints
+
+      contractResult = runContractPure contract mockConfig def
+   in -- Building and siging the tx includes both signing keys
+      [ "cardano-cli query utxo \
+        \--address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+        \--testnet-magic 42"
+      , "cardano-cli transaction build --alonzo-era \
+        \--tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+        \--tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+        \--tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 \
+        \--change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+        \--required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+        \--required-signer signing-keys/signing-key-008b47844d92812fc30d1f0ac9b6fbf38778ccba9db8312ad9079079.skey \
+        \--testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw"
+      , "cardano-cli transaction sign \
+        \--tx-body-file tx.raw \
+        \--signing-key-file signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+        \--signing-key-file signing-keys/signing-key-008b47844d92812fc30d1f0ac9b6fbf38778ccba9db8312ad9079079.skey \
         \--out-file tx.signed"
       ]
         @=? reverse contractResult.commandHistory

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -39,7 +39,7 @@ sendAda =
               ("cardano-cli", "query" : "utxo" : _) ->
                 pure $
                   queryUtxoOut
-                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250)]
+                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1300)]
               ("cardano-cli", "transaction" : "build" : _) ->
                 pure ""
               ("cardano-cli", "transaction" : "sign" : _) ->
@@ -81,7 +81,7 @@ multisigSupport =
               ("cardano-cli", "query" : "utxo" : _) ->
                 pure $
                   queryUtxoOut
-                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1250)]
+                    [("e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5", 0, 1300)]
               ("cardano-cli", "transaction" : "build" : _) ->
                 pure ""
               ("cardano-cli", "transaction" : "sign" : _) ->

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -39,7 +39,7 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
 import Prelude
 
-{- | Project wide tests
+{- | Contract tests
 
  @since 0.1
 -}
@@ -50,6 +50,7 @@ tests =
     [ testCase "Send ada to address" sendAda
     , testCase "Support multiple signatories" multisigSupport
     , testCase "Send native tokens" sendTokens
+    , testCase "Send native tokens (without token name)" sendTokensWithoutName
     , testCase "Mint native tokens" mintTokens
     , testCase "Redeem from validator script" redeemFromValidator
     ]
@@ -171,6 +172,43 @@ sendTokens = do
         --tx-in-collateral ${txId}#0
         --tx-out ${addr1}+50 + 95 abcd1234.testToken
         --tx-out ${addr2}+1000 + 5 abcd1234.testToken
+        --change-address ${addr1}
+        --required-signer signing-keys/signing-key-${pkh1'}.skey
+        --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
+      |]
+
+sendTokensWithoutName :: Assertion
+sendTokensWithoutName = do
+  let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
+      txOut =
+        TxOut
+          (Ledger.pubKeyHashAddress pkh1)
+          (Ada.lovelaceValueOf 1250 <> Value.singleton "abcd1234" "" 100)
+          Nothing
+      initState = def {utxos = [(txOutRef, txOut)]}
+      txId = encodeByteString $ fromBuiltin $ getTxId $ txOutRefId txOutRef
+
+      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract = do
+        let constraints =
+              Constraints.mustPayToPubKey
+                pkh2
+                (Ada.lovelaceValueOf 1000 <> Value.singleton "abcd1234" "" 5)
+        void $ submitTx constraints
+
+      (result, state, _) = runContractPure contract initState
+
+  result @?= Right ()
+  (state.commandHistory !! 1)
+    @?= Text.replace
+      "\n"
+      " "
+      [text|
+        cardano-cli transaction build --alonzo-era
+        --tx-in ${txId}#0
+        --tx-in-collateral ${txId}#0
+        --tx-out ${addr1}+50 + 95 abcd1234
+        --tx-out ${addr2}+1000 + 5 abcd1234
         --change-address ${addr1}
         --required-signer signing-keys/signing-key-${pkh1'}.skey
         --mainnet --protocol-params-file ./protocol.json --out-file tx.raw

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -157,23 +157,15 @@ sendTokens = do
 
       (result, state) = runContractPure contract mockConfig def
   result @?= Right ()
-  state.commandHistory
-    @?= [ "cardano-cli query utxo \
-          \--address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
-          \--testnet-magic 42"
-        , "cardano-cli transaction build --alonzo-era \
-          \--tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
-          \--tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
-          \--tx-out addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35+50 + 95 abcd1234.testToken \
-          \--tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 + 5 abcd1234.testToken \
-          \--change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
-          \--required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
-          \--testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw"
-        , "cardano-cli transaction sign \
-          \--tx-body-file tx.raw \
-          \--signing-key-file signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
-          \--out-file tx.signed"
-        ]
+  (state.commandHistory !! 1)
+    @?= "cardano-cli transaction build --alonzo-era \
+        \--tx-in e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+        \--tx-in-collateral e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5#0 \
+        \--tx-out addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35+50 + 95 abcd1234.testToken \
+        \--tx-out addr_test1vqxk54m7j3q6mrkevcunryrwf4p7e68c93cjk8gzxkhlkpsffv7s0+1000 + 5 abcd1234.testToken \
+        \--change-address addr_test1vr9exkzjnh6898pjg632qv7tnqs6h073dhjg3qq9jp9tcsg8d6n35 \
+        \--required-signer signing-keys/signing-key-cb9358529df4729c3246a2a033cb9821abbfd16de4888005904abc41.skey \
+        \--testnet-magic 42 --protocol-params-file ./protocol.json --out-file tx.raw"
 
 queryUtxoOut :: [(Text, Int, Int, [(Text, Int)])] -> String
 queryUtxoOut utxos =

--- a/test/Spec/MLabsPAB/UtxoParser.hs
+++ b/test/Spec/MLabsPAB/UtxoParser.hs
@@ -1,0 +1,130 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Spec.MLabsPAB.UtxoParser (tests) where
+
+import Data.Attoparsec.Text (parseOnly)
+import Data.Text (Text)
+import Ledger qualified
+import Ledger.Ada qualified as Ada
+import Ledger.Address (Address)
+import Ledger.Tx (
+  ChainIndexTxOut (PublicKeyChainIndexTxOut, ScriptChainIndexTxOut),
+  TxOutRef (TxOutRef),
+ )
+import Ledger.Value qualified as Value
+import MLabsPAB.UtxoParser qualified as UtxoParser
+import NeatInterpolation (text)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Prelude
+
+{- | Tests for 'cardano-cli query utxo' result parsers
+
+ @since 0.1
+-}
+tests :: TestTree
+tests =
+  testGroup
+    "MLabsPAB.UtxoParser"
+    [ testCase "Without utxo" withoutUtxo
+    , testCase "Single utxo, ada only" singleAdaOnly
+    , testCase "Multiple utxos, ada only" multiAdaOnly
+    , testCase "Single utxo, ada and native tokens" singleWithNativeTokens
+    , testCase "Single utxo, with datum" singleWithDatum
+    ]
+
+withoutUtxo :: Assertion
+withoutUtxo = do
+  let addr = Ledger.pubKeyHashAddress "0000"
+  testUtxoParser
+    addr
+    [text|                           TxHash                                 TxIx        Amount
+          --------------------------------------------------------------------------------------
+    |]
+    []
+
+singleAdaOnly :: Assertion
+singleAdaOnly = do
+  let addr = Ledger.pubKeyHashAddress "0000"
+  testUtxoParser
+    addr
+    [text|                           TxHash                                 TxIx        Amount
+          --------------------------------------------------------------------------------------
+          384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51     0        5000000000 lovelace + TxOutDatumNone
+    |]
+    [
+      ( TxOutRef "384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51" 0
+      , PublicKeyChainIndexTxOut addr (Ada.lovelaceValueOf 5000000000)
+      )
+    ]
+
+multiAdaOnly :: Assertion
+multiAdaOnly = do
+  let addr = Ledger.pubKeyHashAddress "0000"
+  testUtxoParser
+    addr
+    [text|                           TxHash                                 TxIx        Amount
+          --------------------------------------------------------------------------------------
+          384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51     0        5000000000 lovelace + TxOutDatumNone
+          52a003b3f4956433429631afe4002f82a924a5a7a891db7ae1f6434797a57dff     1        89835907 lovelace + TxOutDatumNone
+          d8a5630a9d7e913f9d186c95e5138a239a4e79ece3414ac894dbf37280944de3     0        501000123456 lovelace + TxOutDatumNone
+    |]
+    [
+      ( TxOutRef "384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51" 0
+      , PublicKeyChainIndexTxOut addr (Ada.lovelaceValueOf 5000000000)
+      )
+    ,
+      ( TxOutRef "52a003b3f4956433429631afe4002f82a924a5a7a891db7ae1f6434797a57dff" 1
+      , PublicKeyChainIndexTxOut addr (Ada.lovelaceValueOf 89835907)
+      )
+    ,
+      ( TxOutRef "d8a5630a9d7e913f9d186c95e5138a239a4e79ece3414ac894dbf37280944de3" 0
+      , PublicKeyChainIndexTxOut addr (Ada.lovelaceValueOf 501000123456)
+      )
+    ]
+
+singleWithNativeTokens :: Assertion
+singleWithNativeTokens = do
+  let addr = Ledger.pubKeyHashAddress "0000"
+  testUtxoParser
+    addr
+    [text|                           TxHash                                 TxIx        Amount
+          --------------------------------------------------------------------------------------
+          384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51     0        1234 lovelace + 2345 057910a2c93551443cb2c0544d1d65da3fb033deaa79452bd431ee08.testToken + 3456 7c6de14062b27c3dc3ba9f232ade32efe22fb8e2ae76b24f33212fdb.testToken2 + 4567 98a759ed2e20f6d83aa4d37d028d4bbb547a696fc345d54126188614 + TxOutDatumNone
+    |]
+    [
+      ( TxOutRef "384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51" 0
+      , PublicKeyChainIndexTxOut
+          addr
+          ( Ada.lovelaceValueOf 1234
+              <> Value.singleton "057910a2c93551443cb2c0544d1d65da3fb033deaa79452bd431ee08" "testToken" 2345
+              <> Value.singleton "7c6de14062b27c3dc3ba9f232ade32efe22fb8e2ae76b24f33212fdb" "testToken2" 3456
+              <> Value.singleton "98a759ed2e20f6d83aa4d37d028d4bbb547a696fc345d54126188614" "" 4567
+          )
+      )
+    ]
+
+singleWithDatum :: Assertion
+singleWithDatum = do
+  let addr = Ledger.scriptHashAddress "0000"
+  testUtxoParser
+    addr
+    [text|                           TxHash                                 TxIx        Amount
+          --------------------------------------------------------------------------------------
+          384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51     0        5000000000 lovelace + TxOutDatumHash ScriptDataInAlonzoEra "2cdb268baecefad822e5712f9e690e1787f186f5c84c343ffdc060b21f0241e0"
+    |]
+    [
+      ( TxOutRef "384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51" 0
+      , ScriptChainIndexTxOut
+          addr
+          (Left "0000")
+          (Left "2cdb268baecefad822e5712f9e690e1787f186f5c84c343ffdc060b21f0241e0")
+          (Ada.lovelaceValueOf 5000000000)
+      )
+    ]
+
+testUtxoParser :: Address -> Text -> [(TxOutRef, ChainIndexTxOut)] -> Assertion
+testUtxoParser addr output expected =
+  parseOnly (UtxoParser.utxoMapParser addr) output @?= Right expected

--- a/test/Spec/Mock.hs
+++ b/test/Spec/Mock.hs
@@ -1,0 +1,229 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Spec.Mock (
+  signingKey1,
+  signingKey2,
+  runContractPure,
+  toSigningKeyFile,
+  MockConfig (..),
+  runContractPure',
+  MockContractState (..),
+  pubKey1,
+  pubKey2,
+  pkh1,
+  pkh2,
+) where
+
+import Cardano.Api (
+  AsType,
+  FileError (FileError, FileIOError),
+  HasTextEnvelope,
+  PaymentKey,
+  SigningKey (PaymentSigningKey),
+  TextEnvelope,
+  TextEnvelopeDescr,
+  TextEnvelopeError,
+  deserialiseFromTextEnvelope,
+  serialiseToTextEnvelope,
+ )
+import Cardano.Crypto.DSIGN (genKeyDSIGN)
+import Cardano.Crypto.Seed (mkSeedFromBytes)
+import Control.Monad.Freer (Eff, reinterpret3, run)
+import Control.Monad.Freer.Error (Error, runError, throwError)
+import Control.Monad.Freer.State (State, get, modify, runState)
+import Control.Monad.Freer.Writer (Writer, runWriter, tell)
+import Data.Aeson qualified as JSON
+import Data.ByteString qualified as ByteString
+import Data.Default (Default (def))
+import Data.Either.Combinators (fromRight, mapLeft, maybeToRight)
+import Data.List (isPrefixOf)
+import Data.Map (Map)
+import Data.Map qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.UUID qualified as UUID
+import GHC.IO.Exception (IOErrorType (NoSuchThing), IOException (IOError))
+import Ledger qualified
+import Ledger.Crypto (PubKey, PubKeyHash)
+import MLabsPAB.Contract (handleContract)
+import MLabsPAB.Effects (PABEffect (..), ShellArgs (..))
+import MLabsPAB.Files qualified as Files
+import MLabsPAB.Types (ContractEnvironment (..), LogLevel (..))
+import Plutus.Contract (Contract (Contract))
+import Plutus.Contract.Effects (ChainIndexQuery (..), ChainIndexResponse (..))
+import Wallet.Emulator (knownWallet)
+import Wallet.Types (ContractInstanceId (ContractInstanceId))
+import Prelude
+
+signingKey1, signingKey2 :: SigningKey PaymentKey
+signingKey1 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 0
+signingKey2 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 1
+
+pubKey1, pubKey2 :: PubKey
+pubKey1 = toPubKey signingKey1
+pubKey2 = toPubKey signingKey2
+
+pkh1, pkh2 :: PubKeyHash
+pkh1 = Ledger.pubKeyHash pubKey1
+pkh2 = Ledger.pubKeyHash pubKey2
+
+toPubKey :: SigningKey PaymentKey -> PubKey
+toPubKey = Ledger.toPublicKey . fromRight (error "Impossible happened") . Files.fromCardanoPaymentKey
+
+toSigningKeyFile :: FilePath -> SigningKey PaymentKey -> (String, TextEnvelope)
+toSigningKeyFile signingKeyFileDir sKey =
+  ( signingKeyFileDir ++ "/signing-key-" ++ show (Ledger.pubKeyHash (toPubKey sKey)) ++ ".skey"
+  , serialiseToTextEnvelope Nothing sKey
+  )
+
+data MockConfig = MockConfig
+  { handleCliCommand :: (Text, [Text]) -> MockContract String
+  }
+
+data MockContractState = MockContractState
+  { files :: Map FilePath TextEnvelope
+  , commandHistory :: [Text]
+  , contractEnv :: ContractEnvironment
+  }
+  deriving stock (Show, Eq)
+
+instance Default MockContractState where
+  def =
+    MockContractState
+      { files = Map.fromList $ map (toSigningKeyFile "signing-keys") [signingKey1, signingKey1]
+      , commandHistory = mempty
+      , contractEnv = def
+      }
+
+instance Default ContractEnvironment where
+  def =
+    ContractEnvironment
+      { cePABConfig = def
+      , ceContractInstanceId = ContractInstanceId UUID.nil
+      , ceWallet = knownWallet 1
+      , ceOwnPubKey = pubKey1
+      , ceFees = 200
+      , ceMinLovelaces = 50
+      }
+type MockContract a = Eff '[Error (), State MockContractState, Writer [String]] a
+
+runContractPure ::
+  forall w s e a.
+  (Monoid w) =>
+  Contract w s e a ->
+  MockConfig ->
+  MockContractState ->
+  MockContractState
+runContractPure contract config initContractState =
+  snd . fst $ runContractPure' contract config initContractState
+
+runContractPure' ::
+  forall w s e a.
+  (Monoid w) =>
+  Contract w s e a ->
+  MockConfig ->
+  MockContractState ->
+  ((Either () (Either e a, w), MockContractState), [String])
+runContractPure' (Contract effs) config initContractState =
+  runPABEffectPure config initContractState $ handleContract initContractState.contractEnv effs
+
+runPABEffectPure ::
+  MockConfig ->
+  MockContractState ->
+  Eff '[PABEffect] a ->
+  ((Either () a, MockContractState), [String])
+runPABEffectPure config initState req =
+  run (runWriter (runState initState (runError (reinterpret3 go req))))
+  where
+    go :: PABEffect v -> MockContract v
+    go (CallCommand args) = mockCallCommand config.handleCliCommand args
+    go (CreateDirectoryIfMissing createParents filePath) =
+      mockCreateDirectoryIfMissing createParents filePath
+    go (PrintLog logLevel msg) = mockPrintLog logLevel msg
+    go (ThreadDelay microseconds) = mockThreadDelay microseconds
+    go (ReadFileTextEnvelope asType filepath) = mockReadFileTextEnvelope asType filepath
+    go (WriteFileJSON filepath value) = mockWriteFileJSON filepath value
+    go (WriteFileTextEnvelope filepath envelopeDescr contents) =
+      mockWriteFileTextEnvelope filepath envelopeDescr contents
+    go (ListDirectory dir) = mockListDirectory dir
+    go (UploadDir dir) = mockUploadDir dir
+    go (QueryChainIndex query) = mockQueryChainIndex query
+
+mockCallCommand :: ((Text, [Text]) -> MockContract String) -> ShellArgs a -> MockContract a
+mockCallCommand handleCliCommand ShellArgs {cmdName, cmdArgs, cmdOutParser} = do
+  tell $ map Text.unpack cmdArgs
+  modify (\st -> st {commandHistory = cmdName <> " " <> Text.unwords cmdArgs : st.commandHistory})
+
+  cmdOutParser <$> handleCliCommand (cmdName, cmdArgs)
+
+mockCreateDirectoryIfMissing :: Bool -> FilePath -> MockContract ()
+mockCreateDirectoryIfMissing _ _ = pure ()
+
+mockPrintLog :: LogLevel -> String -> MockContract ()
+mockPrintLog _ msg = tell [msg]
+
+mockThreadDelay :: Int -> MockContract ()
+mockThreadDelay _ = pure ()
+
+mockReadFileTextEnvelope ::
+  HasTextEnvelope a =>
+  AsType a ->
+  FilePath ->
+  MockContract (Either (FileError TextEnvelopeError) a)
+mockReadFileTextEnvelope ttoken filepath = do
+  state <- get @MockContractState
+
+  let maybeFile = Map.lookup filepath state.files
+
+  pure $ do
+    te <-
+      maybeToRight
+        (FileIOError filepath (IOError Nothing NoSuchThing "" "No such file in the MockContractState" Nothing Nothing))
+        maybeFile
+    mapLeft (FileError filepath) $ deserialiseFromTextEnvelope ttoken te
+
+mockWriteFileJSON :: FilePath -> JSON.Value -> MockContract (Either (FileError ()) ())
+mockWriteFileJSON _ _ = pure $ Right ()
+
+mockWriteFileTextEnvelope ::
+  HasTextEnvelope a =>
+  FilePath ->
+  Maybe TextEnvelopeDescr ->
+  a ->
+  MockContract (Either (FileError ()) ())
+mockWriteFileTextEnvelope filepath descr content = do
+  modify (\st -> st {files = Map.insert filepath (serialiseToTextEnvelope descr content) st.files})
+
+  pure $ Right ()
+
+mockListDirectory :: FilePath -> MockContract [FilePath]
+mockListDirectory filepath = do
+  state <- get @MockContractState
+  pure $ map (drop (length filepath + 1)) $ filter (filepath `isPrefixOf`) $ Map.keys state.files
+
+mockUploadDir :: Text -> MockContract ()
+mockUploadDir _ = pure ()
+
+mockQueryChainIndex :: ChainIndexQuery -> MockContract ChainIndexResponse
+mockQueryChainIndex = \case
+  DatumFromHash _ ->
+    pure $ DatumHashResponse Nothing
+  ValidatorFromHash _ ->
+    pure $ ValidatorHashResponse Nothing
+  MintingPolicyFromHash _ ->
+    pure $ MintingPolicyHashResponse Nothing
+  StakeValidatorFromHash _ ->
+    pure $ StakeValidatorHashResponse Nothing
+  RedeemerFromHash _ ->
+    pure $ RedeemerHashResponse Nothing
+  TxOutFromRef _ ->
+    pure $ TxOutRefResponse Nothing
+  TxFromTxId _ ->
+    pure $ TxIdResponse Nothing
+  UtxoSetMembership _ ->
+    throwError ()
+  UtxoSetAtAddress _ ->
+    throwError ()
+  GetTip ->
+    throwError ()

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -239,26 +239,7 @@ mockQueryUtxoOut utxos =
             ( \(TxOutRef (TxId txId) txIx, TxOut _ val datumHash) ->
                 let txId' = encodeByteString $ fromBuiltin txId
                     txIx' = Text.pack $ show txIx
-                    amts =
-                      Text.intercalate
-                        " + "
-                        ( map
-                            ( \(curSymbol, tokenName, tAmt) ->
-                                let token =
-                                      if curSymbol == Ada.adaSymbol
-                                        then "lovelace"
-                                        else
-                                          let curSymbol' =
-                                                encodeByteString $
-                                                  fromBuiltin $ Value.unCurrencySymbol curSymbol
-                                              tokenName' =
-                                                decodeUtf8 $
-                                                  fromBuiltin $ Value.unTokenName tokenName
-                                           in [text|${curSymbol'}.${tokenName'}|]
-                                 in Text.pack (show tAmt) <> " " <> token
-                            )
-                            (Value.flattenValue val)
-                        )
+                    amts = valueToUtxoOut val
                     datumHash' = case datumHash of
                       Nothing -> "TxOutDatumNone"
                       Just (DatumHash dh) ->
@@ -267,6 +248,24 @@ mockQueryUtxoOut utxos =
             )
             utxos
       ]
+
+valueToUtxoOut :: Value.Value -> Text
+valueToUtxoOut =
+  Text.intercalate " + " . map stringifyValue' . Value.flattenValue
+  where
+    stringifyValue' (curSymbol, tokenName, tAmt) =
+      let token =
+            if curSymbol == Ada.adaSymbol
+              then "lovelace"
+              else
+                let curSymbol' =
+                      encodeByteString $
+                        fromBuiltin $ Value.unCurrencySymbol curSymbol
+                    tokenName' =
+                      decodeUtf8 $
+                        fromBuiltin $ Value.unTokenName tokenName
+                 in [text|${curSymbol'}.${tokenName'}|]
+       in Text.pack (show tAmt) <> " " <> token
 
 mockCreateDirectoryIfMissing :: Bool -> FilePath -> MockContract ()
 mockCreateDirectoryIfMissing _ _ = pure ()
@@ -292,12 +291,6 @@ mockReadFileTextEnvelope ttoken filepath = do
       Just (TextEnvelopeFile te) ->
         mapLeft (FileError filepath) $ deserialiseFromTextEnvelope ttoken te
       Just _ -> Left $ FileError filepath $ TextEnvelopeAesonDecodeError "Invalid format."
-
--- pure $ do
---   te <-
---     maybeToRight
---       maybeFile
---   mapLeft (FileError filepath) $ deserialiseFromTextEnvelope ttoken te
 
 mockWriteFileJSON :: FilePath -> JSON.Value -> MockContract (Either (FileError ()) ())
 mockWriteFileJSON filepath value = do

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -96,8 +96,11 @@ data MockContractState = MockContractState
 instance Default MockContractState where
   def =
     MockContractState
-      { files = Map.fromList $ map (toSigningKeyFile "signing-keys") 
-          [signingKey1, signingKey2, signingKey3]
+      { files =
+          Map.fromList $
+            map
+              (toSigningKeyFile "signing-keys")
+              [signingKey1, signingKey2, signingKey3]
       , commandHistory = mempty
       , contractEnv = def
       }

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Spec.Mock (
+module Spec.MockContract (
   signingKey1,
   signingKey2,
   runContractPure,
@@ -11,8 +11,10 @@ module Spec.Mock (
   MockContractState (..),
   pubKey1,
   pubKey2,
+  pubKey3,
   pkh1,
   pkh2,
+  pkh3,
 ) where
 
 import Cardano.Api (
@@ -56,17 +58,20 @@ import Wallet.Emulator (knownWallet)
 import Wallet.Types (ContractInstanceId (ContractInstanceId))
 import Prelude
 
-signingKey1, signingKey2 :: SigningKey PaymentKey
+signingKey1, signingKey2, signingKey3 :: SigningKey PaymentKey
 signingKey1 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 0
 signingKey2 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 1
+signingKey3 = PaymentSigningKey $ genKeyDSIGN $ mkSeedFromBytes $ ByteString.replicate 32 2
 
-pubKey1, pubKey2 :: PubKey
+pubKey1, pubKey2, pubKey3 :: PubKey
 pubKey1 = toPubKey signingKey1
 pubKey2 = toPubKey signingKey2
+pubKey3 = toPubKey signingKey3
 
-pkh1, pkh2 :: PubKeyHash
+pkh1, pkh2, pkh3 :: PubKeyHash
 pkh1 = Ledger.pubKeyHash pubKey1
 pkh2 = Ledger.pubKeyHash pubKey2
+pkh3 = Ledger.pubKeyHash pubKey3
 
 toPubKey :: SigningKey PaymentKey -> PubKey
 toPubKey = Ledger.toPublicKey . fromRight (error "Impossible happened") . Files.fromCardanoPaymentKey
@@ -91,7 +96,8 @@ data MockContractState = MockContractState
 instance Default MockContractState where
   def =
     MockContractState
-      { files = Map.fromList $ map (toSigningKeyFile "signing-keys") [signingKey1, signingKey1]
+      { files = Map.fromList $ map (toSigningKeyFile "signing-keys") 
+          [signingKey1, signingKey2, signingKey3]
       , commandHistory = mempty
       , contractEnv = def
       }

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -264,7 +264,9 @@ valueToUtxoOut =
                     tokenName' =
                       decodeUtf8 $
                         fromBuiltin $ Value.unTokenName tokenName
-                 in [text|${curSymbol'}.${tokenName'}|]
+                 in if Text.null tokenName'
+                      then curSymbol'
+                      else [text|${curSymbol'}.${tokenName'}|]
        in Text.pack (show tAmt) <> " " <> token
 
 mockCreateDirectoryIfMissing :: Bool -> FilePath -> MockContract ()


### PR DESCRIPTION
This PR includes a framework for testing the PAB. I changed most IO actions to freer effects, so we can run them as a pure function in the tests, and inspect the cardano-cli calls, and file read/write actions.

I will still need to write more tests and maybe refactor the framework to reduce boilerplate.

Solves: https://github.com/mlabs-haskell/mlabs-pab/issues/3