### PR TITLE
Save tx files with unique file names

### DIFF
--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -158,6 +158,7 @@ test-suite mlabs-pab-test
     , freer-extras
     , freer-simple
     , generic-arbitrary
+    , lens
     , mlabs-pab
     , neat-interpolation
     , plutus-chain-index

--- a/src/MLabsPAB/Contract.hs
+++ b/src/MLabsPAB/Contract.hs
@@ -214,12 +214,12 @@ writeBalancedTx contractEnv tx = do
       CardanoCLI.uploadFiles contractEnv.cePABConfig
 
       CardanoCLI.buildTx contractEnv.cePABConfig contractEnv.ceOwnPubKey tx
-      CardanoCLI.signTx contractEnv.cePABConfig requiredSigners
+      CardanoCLI.signTx contractEnv.cePABConfig tx requiredSigners
 
       result <-
         if contractEnv.cePABConfig.pcDryRun
           then pure Nothing
-          else CardanoCLI.submitTx contractEnv.cePABConfig
+          else CardanoCLI.submitTx contractEnv.cePABConfig tx
 
       case result of
         Just err -> pure $ WriteBalancedTxFailed $ OtherError err

--- a/src/MLabsPAB/Files.hs
+++ b/src/MLabsPAB/Files.hs
@@ -3,6 +3,7 @@ module MLabsPAB.Files (
   validatorScriptFilePath,
   readPrivateKeys,
   signingKeyFilePath,
+  txFilePath,
   readPrivateKey,
   writeAll,
   writePolicyScriptFile,
@@ -45,6 +46,8 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Ledger qualified
 import Ledger.Crypto (PrivateKey, PubKeyHash (PubKeyHash))
+import Ledger.Tx qualified as Tx
+import Ledger.TxId qualified as TxId
 import Ledger.Value qualified as Value
 import MLabsPAB.Effects (
   PABEffect,
@@ -96,6 +99,11 @@ signingKeyFilePath :: PABConfig -> PubKeyHash -> Text
 signingKeyFilePath pabConf (PubKeyHash pubKeyHash) =
   let h = encodeByteString $ fromBuiltin pubKeyHash
    in pabConf.pcSigningKeyFileDir <> "/signing-key-" <> h <> ".skey"
+
+txFilePath :: PABConfig -> Text -> Tx.Tx -> Text
+txFilePath pabConf ext tx =
+  let txId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txId tx
+   in pabConf.pcTxFileDir <> "/tx-" <> txId <> "." <> ext
 
 -- | Compiles and writes a script file under the given folder
 writePolicyScriptFile ::

--- a/src/MLabsPAB/Types.hs
+++ b/src/MLabsPAB/Types.hs
@@ -35,6 +35,8 @@ data PABConfig = PABConfig
     pcScriptFileDir :: !Text
   , -- | Directory name of the signing key files
     pcSigningKeyFileDir :: !Text
+  , -- | Directory name of the transaction files
+    pcTxFileDir :: !Text
   , -- | Protocol params file location relative to the cardano-cli working directory (needed for the cli)
     pcProtocolParamsFile :: !Text
   , -- | Dry run mode will build the tx, but skip the submit step
@@ -70,6 +72,7 @@ instance Default PABConfig where
       , pcProtocolParams = Nothing
       , pcScriptFileDir = "result-scripts"
       , pcSigningKeyFileDir = "signing-keys"
+      , pcTxFileDir = "txs"
       , pcDryRun = True
       , pcProtocolParamsFile = "./protocol.json"
       , pcLogLevel = Info

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -62,7 +62,7 @@ sendAda :: Assertion
 sendAda = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
-      initState = def {utxos = [(txOutRef, txOut)]}
+      initState = def {_utxos = [(txOutRef, txOut)]}
       inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       contract :: Contract () (Endpoint "SendAda" ()) Text Tx
@@ -109,7 +109,7 @@ multisigSupport :: Assertion
 multisigSupport = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
-      initState = def {utxos = [(txOutRef, txOut)]}
+      initState = def {_utxos = [(txOutRef, txOut)]}
       inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       contract :: Contract Text (Endpoint "SendAda" ()) Text Tx
@@ -164,7 +164,7 @@ sendTokens = do
           (Ledger.pubKeyHashAddress pkh1)
           (Ada.lovelaceValueOf 1250 <> Value.singleton "abcd1234" "testToken" 100)
           Nothing
-      initState = def {utxos = [(txOutRef, txOut)]}
+      initState = def {_utxos = [(txOutRef, txOut)]}
       inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       contract :: Contract () (Endpoint "SendAda" ()) Text Tx
@@ -201,7 +201,7 @@ sendTokensWithoutName = do
           (Ledger.pubKeyHashAddress pkh1)
           (Ada.lovelaceValueOf 1250 <> Value.singleton "abcd1234" "" 100)
           Nothing
-      initState = def {utxos = [(txOutRef, txOut)]}
+      initState = def {_utxos = [(txOutRef, txOut)]}
       txId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       contract :: Contract () (Endpoint "SendAda" ()) Text Tx
@@ -234,7 +234,7 @@ mintTokens :: Assertion
 mintTokens = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
-      initState = def {utxos = [(txOutRef, txOut)]}
+      initState = def {_utxos = [(txOutRef, txOut)]}
       inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       mintingPolicy :: Scripts.MintingPolicy
@@ -298,7 +298,7 @@ redeemFromValidator = do
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 100) Nothing
       txOutRef' = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 1
       txOut' = TxOut valAddr (Ada.lovelaceValueOf 1250) (Just datumHash)
-      initState = def {utxos = [(txOutRef, txOut), (txOutRef', txOut')]}
+      initState = def {_utxos = [(txOutRef, txOut), (txOutRef', txOut')]}
       inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       validator :: Scripts.Validator
@@ -377,7 +377,7 @@ multiTx :: Assertion
 multiTx = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
-      initState = def {utxos = [(txOutRef, txOut)]}
+      initState = def {_utxos = [(txOutRef, txOut)]}
 
       contract :: Contract () (Endpoint "SendAda" ()) Text [Tx]
       contract = do
@@ -408,14 +408,14 @@ multiTx = do
 assertFiles :: MockContractState -> [Text] -> Assertion
 assertFiles state files =
   assertBool errorMsg $
-    Set.fromList (map Text.unpack files) `Set.isSubsetOf` Map.keysSet state.files
+    Set.fromList (map Text.unpack files) `Set.isSubsetOf` Map.keysSet state._files
   where
     errorMsg =
       unlines
         [ "expected (at least):"
         , show files
         , "got:"
-        , show (Map.keys state.files)
+        , show (Map.keys state._files)
         ]
 
 assertContractWithTxId ::
@@ -438,5 +438,5 @@ assertCommandHistory :: MockContractState -> [(Int, Text)] -> Assertion
 assertCommandHistory state =
   mapM_
     ( \(idx, expectedCmd) ->
-        state.commandHistory !! idx @?= Text.replace "\n" " " expectedCmd
+        state._commandHistory !! idx @?= Text.replace "\n" " " expectedCmd
     )

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -4,7 +4,6 @@
 
 module Spec.MLabsPAB.Contract (tests) where
 
-import Control.Monad (void)
 import Data.Aeson.Extras (encodeByteString)
 import Data.Default (def)
 import Data.Map qualified as Map
@@ -17,8 +16,9 @@ import Ledger.Ada qualified as Ada
 import Ledger.Address qualified as Address
 import Ledger.Constraints qualified as Constraints
 import Ledger.Scripts qualified as Scripts
-import Ledger.Tx (TxOut (TxOut), TxOutRef (TxOutRef), txOutRefId)
-import Ledger.TxId (getTxId)
+import Ledger.Tx (Tx, TxOut (TxOut), TxOutRef (TxOutRef))
+import Ledger.Tx qualified as Tx
+import Ledger.TxId qualified as TxId
 import Ledger.Value qualified as Value
 import NeatInterpolation (text)
 import Plutus.Contract (Contract (..), Endpoint, submitTx, submitTxConstraintsWith, utxosAt)
@@ -36,7 +36,7 @@ import Spec.MockContract (
   runContractPure,
  )
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (Assertion, assertBool, testCase, (@?=))
+import Test.Tasty.HUnit (Assertion, assertBool, assertFailure, testCase, (@?=))
 import Prelude
 
 {- | Project wide tests
@@ -59,85 +59,91 @@ sendAda = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
       initState = def {utxos = [(txOutRef, txOut)]}
-      txId = encodeByteString $ fromBuiltin $ getTxId $ txOutRefId txOutRef
+      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
-      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract :: Contract () (Endpoint "SendAda" ()) Text Tx
       contract = do
         let constraints =
               Constraints.mustPayToPubKey pkh2 (Ada.lovelaceValueOf 1000)
-        void $ submitTx constraints
+        submitTx constraints
 
       (result, state, _) = runContractPure contract initState
 
-  result @?= Right ()
-  state.commandHistory
-    @?= map
-      (Text.replace "\n" " ")
-      [ [text|
-            cardano-cli query utxo
-            --address ${addr1}
-            --mainnet
-           |]
-      , [text|
-            cardano-cli transaction build --alonzo-era
-            --tx-in ${txId}#0
-            --tx-in-collateral ${txId}#0
-            --tx-out ${addr2}+1000
-            --change-address ${addr1}
-            --required-signer signing-keys/signing-key-${pkh1'}.skey
-            --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
-          |]
-      , [text|
-            cardano-cli transaction sign
-            --tx-body-file tx.raw
-            --signing-key-file signing-keys/signing-key-${pkh1'}.skey
-            --out-file tx.signed
-          |]
-      ]
+  case result of
+    Left errMsg -> assertFailure (show errMsg)
+    Right tx ->
+      let outTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txId tx
+       in state.commandHistory
+            @?= map
+              (Text.replace "\n" " ")
+              [ [text|
+                cardano-cli query utxo
+                --address ${addr1}
+                --mainnet
+               |]
+              , [text|
+                cardano-cli transaction build --alonzo-era
+                --tx-in ${inTxId}#0
+                --tx-in-collateral ${inTxId}#0
+                --tx-out ${addr2}+1000
+                --change-address ${addr1}
+                --required-signer signing-keys/signing-key-${pkh1'}.skey
+                --mainnet --protocol-params-file ./protocol.json --out-file txs/tx-${outTxId}.raw
+              |]
+              , [text|
+                cardano-cli transaction sign
+                --tx-body-file txs/tx-${outTxId}.raw
+                --signing-key-file signing-keys/signing-key-${pkh1'}.skey
+                --out-file txs/tx-${outTxId}.signed
+              |]
+              ]
 
 multisigSupport :: Assertion
 multisigSupport = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
       initState = def {utxos = [(txOutRef, txOut)]}
-      txId = encodeByteString $ fromBuiltin $ getTxId $ txOutRefId txOutRef
+      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
-      contract :: Contract Text (Endpoint "SendAda" ()) Text ()
+      contract :: Contract Text (Endpoint "SendAda" ()) Text Tx
       contract = do
         let constraints =
               Constraints.mustPayToPubKey pkh2 (Ada.lovelaceValueOf 1000)
                 <> Constraints.mustBeSignedBy pkh3
-        void $ submitTx constraints
+        submitTx constraints
 
       (result, state, _) = runContractPure contract initState
   -- Building and siging the tx includes both signing keys
-  result @?= Right ()
-  state.commandHistory
-    @?= map
-      (Text.replace "\n" " ")
-      [ [text|
-          cardano-cli query utxo
-          --address ${addr1}
-          --mainnet
-          |]
-      , [text|
-          cardano-cli transaction build --alonzo-era
-          --tx-in ${txId}#0
-          --tx-in-collateral ${txId}#0
-          --tx-out ${addr2}+1000
-          --change-address ${addr1}
-          --required-signer signing-keys/signing-key-${pkh1'}.skey
-          --required-signer signing-keys/signing-key-${pkh3'}.skey
-          --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
-        |]
-      , [text| 
-          cardano-cli transaction sign
-          --tx-body-file tx.raw
-          --signing-key-file signing-keys/signing-key-${pkh1'}.skey
-          --signing-key-file signing-keys/signing-key-${pkh3'}.skey
-          --out-file tx.signed
-        |]
-      ]
+  case result of
+    Left errMsg -> assertFailure (show errMsg)
+    Right tx ->
+      let outTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txId tx
+       in state.commandHistory
+            @?= map
+              (Text.replace "\n" " ")
+              [ [text|
+                  cardano-cli query utxo
+                  --address ${addr1}
+                  --mainnet
+                  |]
+              , [text|
+                  cardano-cli transaction build --alonzo-era
+                  --tx-in ${inTxId}#0
+                  --tx-in-collateral ${inTxId}#0
+                  --tx-out ${addr2}+1000
+                  --change-address ${addr1}
+                  --required-signer signing-keys/signing-key-${pkh1'}.skey
+                  --required-signer signing-keys/signing-key-${pkh3'}.skey
+                  --mainnet --protocol-params-file ./protocol.json --out-file txs/tx-${outTxId}.raw
+                |]
+              , [text| 
+                  cardano-cli transaction sign
+                  --tx-body-file txs/tx-${outTxId}.raw
+                  --signing-key-file signing-keys/signing-key-${pkh1'}.skey
+                  --signing-key-file signing-keys/signing-key-${pkh3'}.skey
+                  --out-file txs/tx-${outTxId}.signed
+                |]
+              ]
 
 sendTokens :: Assertion
 sendTokens = do
@@ -148,40 +154,43 @@ sendTokens = do
           (Ada.lovelaceValueOf 1250 <> Value.singleton "abcd1234" "testToken" 100)
           Nothing
       initState = def {utxos = [(txOutRef, txOut)]}
-      txId = encodeByteString $ fromBuiltin $ getTxId $ txOutRefId txOutRef
+      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
-      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract :: Contract () (Endpoint "SendAda" ()) Text Tx
       contract = do
         let constraints =
               Constraints.mustPayToPubKey
                 pkh2
                 (Ada.lovelaceValueOf 1000 <> Value.singleton "abcd1234" "testToken" 5)
-        void $ submitTx constraints
+        submitTx constraints
 
       (result, state, _) = runContractPure contract initState
 
-  result @?= Right ()
-  (state.commandHistory !! 1)
-    @?= Text.replace
-      "\n"
-      " "
-      [text|
-        cardano-cli transaction build --alonzo-era
-        --tx-in ${txId}#0
-        --tx-in-collateral ${txId}#0
-        --tx-out ${addr1}+50 + 95 abcd1234.testToken
-        --tx-out ${addr2}+1000 + 5 abcd1234.testToken
-        --change-address ${addr1}
-        --required-signer signing-keys/signing-key-${pkh1'}.skey
-        --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
-      |]
+  case result of
+    Left errMsg -> assertFailure (show errMsg)
+    Right tx ->
+      let outTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txId tx
+       in (state.commandHistory !! 1)
+            @?= Text.replace
+              "\n"
+              " "
+              [text|
+              cardano-cli transaction build --alonzo-era
+              --tx-in ${inTxId}#0
+              --tx-in-collateral ${inTxId}#0
+              --tx-out ${addr1}+50 + 95 abcd1234.testToken
+              --tx-out ${addr2}+1000 + 5 abcd1234.testToken
+              --change-address ${addr1}
+              --required-signer signing-keys/signing-key-${pkh1'}.skey
+              --mainnet --protocol-params-file ./protocol.json --out-file txs/tx-${outTxId}.raw
+            |]
 
 mintTokens :: Assertion
 mintTokens = do
   let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
       txOut = TxOut (Ledger.pubKeyHashAddress pkh1) (Ada.lovelaceValueOf 1250) Nothing
       initState = def {utxos = [(txOutRef, txOut)]}
-      txId = encodeByteString $ fromBuiltin $ getTxId $ txOutRefId txOutRef
+      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       mintingPolicy :: Scripts.MintingPolicy
       mintingPolicy =
@@ -198,7 +207,7 @@ mintTokens = do
         let (Scripts.RedeemerHash rh) = Ledger.redeemerHash Ledger.unitRedeemer
          in encodeByteString $ fromBuiltin rh
 
-      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract :: Contract () (Endpoint "SendAda" ()) Text Tx
       contract = do
         let lookups =
               Constraints.mintingPolicy mintingPolicy
@@ -207,33 +216,35 @@ mintTokens = do
                 <> Constraints.mustPayToPubKey
                   pkh2
                   (Ada.lovelaceValueOf 1000 <> Value.singleton curSymbol "testToken" 5)
-        void $ submitTxConstraintsWith @Void lookups constraints
+        submitTxConstraintsWith @Void lookups constraints
 
       (result, state, _) = runContractPure contract initState
 
-  result @?= Right ()
-  (state.commandHistory !! 1)
-    @?= Text.replace
-      "\n"
-      " "
-      [text| cardano-cli transaction build --alonzo-era
-       --tx-in ${txId}#0
-       --tx-in-collateral ${txId}#0
-       --tx-out ${addr2}+1000 + 5 ${curSymbol'}.testToken
-       --mint-script-file result-scripts/policy-${curSymbol'}.plutus
-       --mint-redeemer-file result-scripts/redeemer-${redeemerHash}.json
-       --mint 5 ${curSymbol'}.testToken
-       --change-address ${addr1}
-       --required-signer signing-keys/signing-key-${pkh1'}.skey
-       --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
-      |]
-
-  assertFiles
-    state
-    [ [text|result-scripts/policy-${curSymbol'}.plutus|]
-    , [text|result-scripts/redeemer-${redeemerHash}.json|]
-    , [text|signing-keys/signing-key-${pkh1'}.skey|]
-    ]
+  case result of
+    Left errMsg -> assertFailure (show errMsg)
+    Right tx -> do
+      let outTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txId tx
+      (state.commandHistory !! 1)
+        @?= Text.replace
+          "\n"
+          " "
+          [text| cardano-cli transaction build --alonzo-era
+             --tx-in ${inTxId}#0
+             --tx-in-collateral ${inTxId}#0
+             --tx-out ${addr2}+1000 + 5 ${curSymbol'}.testToken
+             --mint-script-file result-scripts/policy-${curSymbol'}.plutus
+             --mint-redeemer-file result-scripts/redeemer-${redeemerHash}.json
+             --mint 5 ${curSymbol'}.testToken
+             --change-address ${addr1}
+             --required-signer signing-keys/signing-key-${pkh1'}.skey
+             --mainnet --protocol-params-file ./protocol.json --out-file txs/tx-${outTxId}.raw
+            |]
+      assertFiles
+        state
+        [ [text|result-scripts/policy-${curSymbol'}.plutus|]
+        , [text|result-scripts/redeemer-${redeemerHash}.json|]
+        , [text|signing-keys/signing-key-${pkh1'}.skey|]
+        ]
 
 redeemFromValidator :: Assertion
 redeemFromValidator = do
@@ -242,7 +253,7 @@ redeemFromValidator = do
       txOutRef' = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 1
       txOut' = TxOut valAddr (Ada.lovelaceValueOf 1250) (Just datumHash)
       initState = def {utxos = [(txOutRef, txOut), (txOutRef', txOut')]}
-      txId = encodeByteString $ fromBuiltin $ getTxId $ txOutRefId txOutRef
+      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
 
       validator :: Scripts.Validator
       validator =
@@ -274,7 +285,7 @@ redeemFromValidator = do
         let (Scripts.RedeemerHash rh) = Ledger.redeemerHash Ledger.unitRedeemer
          in encodeByteString $ fromBuiltin rh
 
-      contract :: Contract () (Endpoint "SendAda" ()) Text ()
+      contract :: Contract () (Endpoint "SendAda" ()) Text Tx
       contract = do
         utxos <- utxosAt valAddr
         let lookups =
@@ -284,33 +295,36 @@ redeemFromValidator = do
         let constraints =
               Constraints.mustSpendScriptOutput txOutRef' Ledger.unitRedeemer
                 <> Constraints.mustPayToPubKey pkh2 (Ada.lovelaceValueOf 500)
-        void $ submitTxConstraintsWith @Void lookups constraints
+        submitTxConstraintsWith @Void lookups constraints
 
       (result, state, _) = runContractPure contract initState
 
-  result @?= Right ()
-  (state.commandHistory !! 1)
-    @?= Text.replace
-      "\n"
-      " "
-      [text| cardano-cli transaction build --alonzo-era
-       --tx-in ${txId}#1
-       --tx-in-script-file result-scripts/validator-${valHash'}.plutus
-       --tx-in-datum-file result-scripts/datum-${datumHash'}.json
-       --tx-in-redeemer-file result-scripts/redeemer-${redeemerHash}.json
-       --tx-in-collateral ${txId}#0
-       --tx-out ${addr2}+500
-       --change-address ${addr1}
-       --required-signer signing-keys/signing-key-${pkh1'}.skey
-       --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
-      |]
-  assertFiles
-    state
-    [ [text|result-scripts/datum-${datumHash'}.json|]
-    , [text|result-scripts/redeemer-${redeemerHash}.json|]
-    , [text|result-scripts/validator-${valHash'}.plutus|]
-    , [text|signing-keys/signing-key-${pkh1'}.skey|]
-    ]
+  case result of
+    Left errMsg -> assertFailure (show errMsg)
+    Right tx -> do
+      let outTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txId tx
+      (state.commandHistory !! 1)
+        @?= Text.replace
+          "\n"
+          " "
+          [text| cardano-cli transaction build --alonzo-era
+             --tx-in ${inTxId}#1
+             --tx-in-script-file result-scripts/validator-${valHash'}.plutus
+             --tx-in-datum-file result-scripts/datum-${datumHash'}.json
+             --tx-in-redeemer-file result-scripts/redeemer-${redeemerHash}.json
+             --tx-in-collateral ${inTxId}#0
+             --tx-out ${addr2}+500
+             --change-address ${addr1}
+             --required-signer signing-keys/signing-key-${pkh1'}.skey
+             --mainnet --protocol-params-file ./protocol.json --out-file txs/tx-${outTxId}.raw
+            |]
+      assertFiles
+        state
+        [ [text|result-scripts/datum-${datumHash'}.json|]
+        , [text|result-scripts/redeemer-${redeemerHash}.json|]
+        , [text|result-scripts/validator-${valHash'}.plutus|]
+        , [text|signing-keys/signing-key-${pkh1'}.skey|]
+        ]
 
 assertFiles :: MockContractState -> [Text] -> Assertion
 assertFiles state files =


### PR DESCRIPTION
Solves: #11
Adding tx files unique names, so they don't clash when multiple txs are built at the same time.