### PR TITLE
Fee calculation using the cli

### DIFF
--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -87,14 +87,14 @@ library
 
   other-modules:   MLabsPAB.Server
   build-depends:
-    , aeson                ^>=1.5.0.0
+    , aeson                  ^>=1.5.0.0
     , aeson-casing
     , ansi-terminal
-    , attoparsec           >=0.13.2.2
-    , bytestring           ^>=0.10.12.0
+    , attoparsec             >=0.13.2.2
+    , bytestring             ^>=0.10.12.0
     , cardano-api
     , cardano-crypto
-    , cardano-prelude
+    , cardano-ledger-alonzo
     , containers
     , cryptonite
     , data-default
@@ -127,11 +127,11 @@ library
     , servant-websockets
     , split
     , stm
-    , text                 ^>=1.2.4.0
+    , text                   ^>=1.2.4.0
     , transformers
     , transformers-either
     , uuid
-    , vector               ^>=0.12.1.2
+    , vector                 ^>=0.12.1.2
     , wai
     , warp
     , websockets

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -81,13 +81,11 @@ library
     MLabsPAB.Contract
     MLabsPAB.Effects
     MLabsPAB.Files
+    MLabsPAB.PreBalance
     MLabsPAB.Types
     MLabsPAB.UtxoParser
 
-  other-modules:
-    MLabsPAB.PreBalance
-    MLabsPAB.Server
-
+  other-modules:   MLabsPAB.Server
   build-depends:
     , aeson                ^>=1.5.0.0
     , aeson-casing
@@ -147,6 +145,7 @@ test-suite mlabs-pab-test
   ghc-options:    -fplugin-opt PlutusTx.Plugin:defer-errors
   other-modules:
     Spec.MLabsPAB.Contract
+    Spec.MLabsPAB.PreBalance
     Spec.MLabsPAB.UtxoParser
     Spec.MockContract
 

--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -89,11 +89,11 @@ library
     MLabsPAB.Server
 
   build-depends:
-    , aeson               ^>=1.5.0.0
+    , aeson                ^>=1.5.0.0
     , aeson-casing
     , ansi-terminal
-    , attoparsec          >=0.13.2.2
-    , bytestring          ^>=0.10.12.0
+    , attoparsec           >=0.13.2.2
+    , bytestring           ^>=0.10.12.0
     , cardano-api
     , cardano-crypto
     , cardano-prelude
@@ -129,9 +129,11 @@ library
     , servant-websockets
     , split
     , stm
-    , text                ^>=1.2.4.0
+    , text                 ^>=1.2.4.0
+    , transformers
+    , transformers-either
     , uuid
-    , vector              ^>=0.12.1.2
+    , vector               ^>=0.12.1.2
     , wai
     , warp
     , websockets

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NamedFieldPuns #-}
 module MLabsPAB.CardanoCLI (
   submitTx,
   calculateMinUtxo,

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module MLabsPAB.CardanoCLI (
+  BuildMode (..),
   submitTx,
   calculateMinUtxo,
   calculateMinFee,
@@ -14,16 +15,19 @@ module MLabsPAB.CardanoCLI (
 ) where
 
 import Cardano.Api.Shelley (NetworkId (Mainnet, Testnet), NetworkMagic (..), serialiseAddress)
+import Codec.Serialise qualified as Codec
 import Control.Monad.Freer (Eff, Member)
 import Data.Aeson.Extras (encodeByteString)
 import Data.Attoparsec.Text (parseOnly)
+import Data.ByteString.Lazy qualified as LazyByteString
+import Data.ByteString.Short qualified as ShortByteString
 import Data.Either (fromRight)
-import Data.Either.Combinators (mapLeft)
+import Data.Either.Combinators (mapLeft, maybeToRight)
 import Data.Kind (Type)
 import Data.List (sort)
 import Data.Map (Map)
 import Data.Map qualified as Map
-import Data.Maybe (isJust, maybeToList)
+import Data.Maybe (maybeToList)
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
@@ -60,7 +64,16 @@ import MLabsPAB.Files (
 import MLabsPAB.Types (PABConfig)
 import MLabsPAB.UtxoParser qualified as UtxoParser
 import Plutus.Contract.CardanoAPI (toCardanoAddress)
-import Plutus.V1.Ledger.Api (CurrencySymbol (..), TokenName (..))
+import Plutus.V1.Ledger.Api (
+  BuiltinData,
+  CurrencySymbol (..),
+  ExBudget (..),
+  ExCPU (..),
+  ExMemory (..),
+  Script,
+  TokenName (..),
+ )
+import Plutus.V1.Ledger.Api qualified as Plutus
 import PlutusTx.Builtins (fromBuiltin)
 import Prelude
 
@@ -144,6 +157,13 @@ calculateMinFee pabConf UnbalancedTx {unBalancedTxRequiredSignatories, unBalance
       , cmdOutParser = mapLeft Text.pack . parseOnly UtxoParser.feeParser . Text.pack
       }
 
+data BuildMode = BuildRaw Integer | BuildAuto
+  deriving stock (Show)
+
+isRawBuildMode :: BuildMode -> Bool
+isRawBuildMode (BuildRaw _) = True
+isRawBuildMode _ = False
+
 {- | Build a tx body and write it to disk
  If a fee if specified, it uses the build-raw command
 -}
@@ -152,10 +172,10 @@ buildTx ::
   Member PABEffect effs =>
   PABConfig ->
   PubKeyHash ->
-  Maybe Integer ->
+  BuildMode ->
   Tx ->
   Eff effs ()
-buildTx pabConf ownPkh maybeFee tx =
+buildTx pabConf ownPkh buildMode tx =
   callCommand $ ShellArgs "cardano-cli" opts (const ())
   where
     ownAddr = Ledger.pubKeyHashAddress ownPkh
@@ -165,15 +185,15 @@ buildTx pabConf ownPkh maybeFee tx =
         (Map.keys (Ledger.txSignatures tx))
     opts =
       mconcat
-        [ ["transaction", if isJust maybeFee then "build-raw" else "build", "--alonzo-era"]
-        , txInOpts pabConf (txInputs tx)
+        [ ["transaction", if isRawBuildMode buildMode then "build-raw" else "build", "--alonzo-era"]
+        , txInOpts pabConf buildMode (txInputs tx)
         , txInCollateralOpts (txCollateral tx)
         , txOutOpts pabConf (txOutputs tx)
-        , mintOpts pabConf (txMintScripts tx) (txRedeemers tx) (txMint tx)
+        , mintOpts pabConf buildMode (txMintScripts tx) (txRedeemers tx) (txMint tx)
         , requiredSigners
-        , case maybeFee of
-            Just fee -> ["--fee", showText fee]
-            Nothing ->
+        , case buildMode of
+            BuildRaw fee -> ["--fee", showText fee]
+            BuildAuto ->
               mconcat
                 [ ["--change-address", unsafeSerialiseAddress pabConf.pcNetwork ownAddr]
                 , networkOpt pabConf
@@ -233,28 +253,36 @@ submitTx pabConf =
           . Text.pack
       )
 
-txInOpts :: PABConfig -> Set TxIn -> [Text]
-txInOpts pabConf =
+txInOpts :: PABConfig -> BuildMode -> Set TxIn -> [Text]
+txInOpts pabConf buildMode =
   concatMap
     ( \(TxIn txOutRef txInType) ->
         mconcat
           [ ["--tx-in", txOutRefToCliArg txOutRef]
           , case txInType of
               Just (ConsumeScriptAddress validator redeemer datum) ->
-                mconcat
-                  [
-                    [ "--tx-in-script-file"
-                    , validatorScriptFilePath pabConf (Ledger.validatorHash validator)
-                    ]
-                  ,
-                    [ "--tx-in-datum-file"
-                    , datumJsonFilePath pabConf (Ledger.datumHash datum)
-                    ]
-                  ,
-                    [ "--tx-in-redeemer-file"
-                    , redeemerJsonFilePath pabConf (Ledger.redeemerHash redeemer)
-                    ]
-                  ]
+                let exBudget =
+                      fromRight (ExBudget (ExCPU 0) (ExMemory 0)) $
+                        calculateExBudget
+                          (Scripts.unValidatorScript validator)
+                          [Plutus.getRedeemer redeemer, Plutus.getDatum datum]
+                 in mconcat
+                      [
+                        [ "--tx-in-script-file"
+                        , validatorScriptFilePath pabConf (Ledger.validatorHash validator)
+                        ]
+                      ,
+                        [ "--tx-in-datum-file"
+                        , datumJsonFilePath pabConf (Ledger.datumHash datum)
+                        ]
+                      ,
+                        [ "--tx-in-redeemer-file"
+                        , redeemerJsonFilePath pabConf (Ledger.redeemerHash redeemer)
+                        ]
+                      , if isRawBuildMode buildMode
+                          then ["--tx-in-execution-units", exBudgetToCliArg exBudget]
+                          else []
+                      ]
               Just ConsumePublicKeyAddress -> []
               Just ConsumeSimpleScriptAddress -> []
               Nothing -> []
@@ -267,8 +295,8 @@ txInCollateralOpts =
   concatMap (\(TxIn txOutRef _) -> ["--tx-in-collateral", txOutRefToCliArg txOutRef]) . Set.toList
 
 -- Minting options
-mintOpts :: PABConfig -> Set Scripts.MintingPolicy -> Redeemers -> Value -> [Text]
-mintOpts pabConf mintingPolicies redeemers mintValue =
+mintOpts :: PABConfig -> BuildMode -> Set Scripts.MintingPolicy -> Redeemers -> Value -> [Text]
+mintOpts pabConf buildMode mintingPolicies redeemers mintValue =
   mconcat
     [ mconcat $
         concatMap
@@ -276,9 +304,17 @@ mintOpts pabConf mintingPolicies redeemers mintValue =
               let redeemerPtr = RedeemerPtr Mint idx
                   redeemer = Map.lookup redeemerPtr redeemers
                   curSymbol = Value.mpsSymbol $ Scripts.mintingPolicyHash policy
+                  exBudget r =
+                    fromRight (ExBudget (ExCPU 0) (ExMemory 0)) $
+                      calculateExBudget
+                        (Scripts.unMintingPolicyScript policy)
+                        [Plutus.getRedeemer r]
                   toOpts r =
                     [ ["--mint-script-file", policyScriptFilePath pabConf curSymbol]
                     , ["--mint-redeemer-file", redeemerJsonFilePath pabConf (Ledger.redeemerHash r)]
+                    , if isRawBuildMode buildMode
+                        then ["--mint-execution-units", exBudgetToCliArg (exBudget r)]
+                        else []
                     ]
                in mconcat $ maybeToList $ fmap toOpts redeemer
           )
@@ -332,6 +368,19 @@ unsafeSerialiseAddress network address =
   case serialiseAddress <$> toCardanoAddress network address of
     Right a -> a
     Left _ -> error "Couldn't create address"
+
+calculateExBudget :: Script -> [BuiltinData] -> Either Text ExBudget
+calculateExBudget script builtinData = do
+  modelParams <- maybeToRight "Cost model params invalid." Plutus.defaultCostModelParams
+  let serialisedScript = ShortByteString.toShort $ LazyByteString.toStrict $ Codec.serialise script
+  let pData = map Plutus.builtinDataToData builtinData
+  mapLeft showText $
+    snd $
+      Plutus.evaluateScriptCounting Plutus.Verbose modelParams serialisedScript pData
+
+exBudgetToCliArg :: ExBudget -> Text
+exBudgetToCliArg (ExBudget (ExCPU steps) (ExMemory memory)) =
+  "(" <> showText steps <> "," <> showText memory <> ")"
 
 showText :: forall (a :: Type). Show a => a -> Text
 showText = Text.pack . show

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NamedFieldPuns #-}
+
 module MLabsPAB.CardanoCLI (
   submitTx,
   calculateMinUtxo,

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -148,9 +148,9 @@ calculateMinFee pabConf UnbalancedTx {unBalancedTxRequiredSignatories, unBalance
           mconcat
             [ ["transaction", "calculate-min-fee"]
             , ["--tx-body-file", "tx.raw"]
-            , ["--tx-in-count", showText $ 1 + length (txInputs unBalancedTxTx)]
+            , ["--tx-in-count", showText $ length $ txInputs unBalancedTxTx]
             , ["--tx-out-count", showText $ length $ txOutputs unBalancedTxTx]
-            , ["--witness-count", showText $ 1 + length (Map.keys unBalancedTxRequiredSignatories)]
+            , ["--witness-count", showText $ length $ Map.keys unBalancedTxRequiredSignatories]
             , ["--protocol-params-file", pabConf.pcProtocolParamsFile]
             , networkOpt pabConf
             ]

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -138,9 +138,9 @@ calculateMinFee ::
   forall (effs :: [Type -> Type]).
   Member PABEffect effs =>
   PABConfig ->
-  UnbalancedTx ->
+  Tx ->
   Eff effs (Either Text Integer)
-calculateMinFee pabConf UnbalancedTx {unBalancedTxRequiredSignatories, unBalancedTxTx} =
+calculateMinFee pabConf tx =
   callCommand
     ShellArgs
       { cmdName = "cardano-cli"
@@ -148,9 +148,9 @@ calculateMinFee pabConf UnbalancedTx {unBalancedTxRequiredSignatories, unBalance
           mconcat
             [ ["transaction", "calculate-min-fee"]
             , ["--tx-body-file", "tx.raw"]
-            , ["--tx-in-count", showText $ length $ txInputs unBalancedTxTx]
-            , ["--tx-out-count", showText $ length $ txOutputs unBalancedTxTx]
-            , ["--witness-count", showText $ length $ Map.keys unBalancedTxRequiredSignatories]
+            , ["--tx-in-count", showText $ length $ txInputs tx]
+            , ["--tx-out-count", showText $ length $ txOutputs tx]
+            , ["--witness-count", showText $ length $ txSignatures tx]
             , ["--protocol-params-file", pabConf.pcProtocolParamsFile]
             , networkOpt pabConf
             ]

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module MLabsPAB.CardanoCLI (
   submitTx,
   calculateMinUtxo,
@@ -170,13 +168,16 @@ buildTx pabConf ownPkh maybeFee tx =
         , txInCollateralOpts (txCollateral tx)
         , txOutOpts pabConf (txOutputs tx)
         , mintOpts pabConf (txMintScripts tx) (txRedeemers tx) (txMint tx)
+        , requiredSigners
         , case maybeFee of
             Just fee -> ["--fee", showText fee]
-            Nothing -> ["--change-address", unsafeSerialiseAddress pabConf.pcNetwork ownAddr]
+            Nothing ->
+              mconcat
+                [ ["--change-address", unsafeSerialiseAddress pabConf.pcNetwork ownAddr]
+                , networkOpt pabConf
+                ]
         , mconcat
-            [ requiredSigners
-            , networkOpt pabConf
-            , ["--protocol-params-file", pabConf.pcProtocolParamsFile]
+            [ ["--protocol-params-file", pabConf.pcProtocolParamsFile]
             , ["--out-file", "tx.raw"]
             ]
         ]

--- a/src/MLabsPAB/Contract.hs
+++ b/src/MLabsPAB/Contract.hs
@@ -143,9 +143,7 @@ balanceTx ::
   ContractEnvironment ->
   UnbalancedTx ->
   Eff effs BalanceTxResponse
-balanceTx contractEnv UnbalancedTx {unBalancedTxTx, unBalancedTxUtxoIndex, unBalancedTxRequiredSignatories} = do
-  -- TODO: getting own address from pub key
-  let ownPkh = Ledger.pubKeyHash contractEnv.ceOwnPubKey
+balanceTx contractEnv unbalancedTx = do
   -- TODO: Handle paging
   -- (_, Page {pageItems}) <-
   --   chainIndexQueryMany $
@@ -156,22 +154,11 @@ balanceTx contractEnv UnbalancedTx {unBalancedTxTx, unBalancedTxUtxoIndex, unBal
   --       Map.fromList $
   --         catMaybes $ zipWith (\oref txout -> (,) <$> Just oref <*> txout) pageItems chainIndexTxOuts
 
-  utxos <- CardanoCLI.utxosAt contractEnv.cePABConfig $ Ledger.pubKeyHashAddress ownPkh
-  privKeys <-
-    either (error . Text.unpack) id
-      <$> Files.readPrivateKeys contractEnv.cePABConfig
-
-  let utxoIndex = fmap Tx.toTxOut utxos <> unBalancedTxUtxoIndex
-  printLog Debug $ show utxoIndex
-  let eitherPreBalancedTx =
-        PreBalance.preBalanceTx
-          contractEnv.ceMinLovelaces
-          contractEnv.ceFees
-          utxoIndex
-          ownPkh
-          privKeys
-          (Map.keys unBalancedTxRequiredSignatories)
-          unBalancedTxTx
+  eitherPreBalancedTx <-
+    PreBalance.preBalanceTx
+      contractEnv.cePABConfig
+      (Ledger.pubKeyHash contractEnv.ceOwnPubKey)
+      unbalancedTx
 
   case eitherPreBalancedTx of
     Left err -> pure $ BalanceTxFailed (InsufficientFunds err)
@@ -209,11 +196,12 @@ writeBalancedTx contractEnv tx = do
           OtherError $
             "Failed to write script file(s): " <> Text.pack (show err)
     Right _ -> do
+      let ownPkh = Ledger.pubKeyHash contractEnv.ceOwnPubKey
       let requiredSigners = Map.keys $ tx ^. Tx.signatures
 
       CardanoCLI.uploadFiles contractEnv.cePABConfig
 
-      CardanoCLI.buildTx contractEnv.cePABConfig contractEnv.ceOwnPubKey tx
+      CardanoCLI.buildTx contractEnv.cePABConfig ownPkh Nothing tx
       CardanoCLI.signTx contractEnv.cePABConfig requiredSigners
 
       result <-

--- a/src/MLabsPAB/Contract.hs
+++ b/src/MLabsPAB/Contract.hs
@@ -200,7 +200,7 @@ writeBalancedTx contractEnv tx = do
 
       CardanoCLI.uploadFiles contractEnv.cePABConfig
 
-      CardanoCLI.buildTx contractEnv.cePABConfig ownPkh Nothing tx
+      CardanoCLI.buildTx contractEnv.cePABConfig ownPkh CardanoCLI.BuildAuto tx
       CardanoCLI.signTx contractEnv.cePABConfig requiredSigners
 
       result <-

--- a/src/MLabsPAB/Contract.hs
+++ b/src/MLabsPAB/Contract.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 
 module MLabsPAB.Contract (runContract, handleContract) where
@@ -155,7 +154,7 @@ balanceTx contractEnv unbalancedTx = do
   --         catMaybes $ zipWith (\oref txout -> (,) <$> Just oref <*> txout) pageItems chainIndexTxOuts
 
   eitherPreBalancedTx <-
-    PreBalance.preBalanceTx
+    PreBalance.preBalanceTxIO
       contractEnv.cePABConfig
       (Ledger.pubKeyHash contractEnv.ceOwnPubKey)
       unbalancedTx

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -69,7 +69,7 @@ preBalanceTxIO pabConf ownPkh tx =
         hoistEither $ preBalanceTx minUtxo 0 utxoIndex ownPkh privKeys requiredSigs tx'
 
       lift $ CardanoCLI.buildTx pabConf ownPkh (CardanoCLI.BuildRaw 0) txWithoutFees
-      fees <- newEitherT $ CardanoCLI.calculateMinFee pabConf tx
+      fees <- newEitherT $ CardanoCLI.calculateMinFee pabConf txWithoutFees
 
       lift $ printLog Debug $ show utxoIndex
 

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -196,7 +196,7 @@ balanceNonAdaOuts ownPkh utxos tx =
           (txOut@TxOut {txOutValue = v} : txOuts, txOuts') ->
             txOut {txOutValue = v <> nonAdaChange} : (txOuts <> txOuts')
    in if isValueNat nonAdaChange
-        then if Value.isZero nonAdaChange then Right tx else Right $ tx {txOutputs = outputs}
+        then Right $ if Value.isZero nonAdaChange then tx else tx {txOutputs = outputs}
         else Left "Not enough inputs to balance tokens."
 
 {- | Add the required signatorioes to the transaction. Be aware the the signature itself is invalid,

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -68,7 +68,7 @@ preBalanceTxIO pabConf ownPkh tx =
       txWithoutFees <-
         hoistEither $ preBalanceTx minUtxo 0 utxoIndex ownPkh privKeys requiredSigs tx'
 
-      lift $ CardanoCLI.buildTx pabConf ownPkh (Just 0) txWithoutFees
+      lift $ CardanoCLI.buildTx pabConf ownPkh (CardanoCLI.BuildRaw 0) txWithoutFees
       fees <- newEitherT $ CardanoCLI.calculateMinFee pabConf tx
 
       lift $ printLog Debug $ show utxoIndex

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -90,6 +90,7 @@ preBalanceTx minUtxo fees utxos ownPkh privKeys requiredSigs tx =
     >>= balanceNonAdaOuts ownPkh utxos
     >>= Right . addLovelaces minUtxo
     >>= balanceTxIns utxos fees -- Adding more inputs if required
+    >>= balanceNonAdaOuts ownPkh utxos
     >>= addSignatories ownPkh privKeys requiredSigs
 
 -- | Getting the necessary utxos to cover the fees for the transaction

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -1,13 +1,12 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module MLabsPAB.PreBalance (
   preBalanceTx,
+  preBalanceTxIO,
 ) where
 
 import Control.Monad (foldM)
 import Control.Monad.Freer (Eff, Member)
 import Control.Monad.Trans.Class (lift)
-import Control.Monad.Trans.Either (newEitherT, runEitherT)
+import Control.Monad.Trans.Either (hoistEither, newEitherT, runEitherT)
 import Data.Either.Combinators (rightToMaybe)
 import Data.Kind (Type)
 import Data.List (partition)
@@ -48,65 +47,78 @@ import Prelude
 {- | Collect necessary tx inputs and collaterals, add minimum lovelace values and balance non ada
  assets
 -}
-preBalanceTx ::
+preBalanceTxIO ::
   forall (effs :: [Type -> Type]).
   Member PABEffect effs =>
   PABConfig ->
   PubKeyHash ->
   UnbalancedTx ->
   Eff effs (Either Text Tx)
-preBalanceTx pabConf ownPkh tx =
+preBalanceTxIO pabConf ownPkh tx =
   runEitherT $
     do
       utxos <- lift $ CardanoCLI.utxosAt pabConf $ Ledger.pubKeyHashAddress ownPkh
       privKeys <- newEitherT $ Files.readPrivateKeys pabConf
-
       let utxoIndex = fmap Tx.toTxOut utxos <> unBalancedTxUtxoIndex tx
-      lift $ printLog Debug $ show utxoIndex
+          tx' = unBalancedTxTx tx
+          requiredSigs = Map.keys (unBalancedTxRequiredSignatories tx)
 
       minUtxo <- newEitherT $ CardanoCLI.calculateMinUtxo pabConf tx
-      lift $ CardanoCLI.buildTx pabConf ownPkh (Just 0) (unBalancedTxTx tx)
 
+      txWithoutFees <-
+        hoistEither $ preBalanceTx minUtxo 0 utxoIndex ownPkh privKeys requiredSigs tx'
+
+      lift $ CardanoCLI.buildTx pabConf ownPkh (Just 0) txWithoutFees
       fees <- newEitherT $ CardanoCLI.calculateMinFee pabConf tx
 
-      newEitherT $
-        pure $
-          addTxCollaterals utxoIndex (unBalancedTxTx tx)
-            >>= balanceTxIns utxoIndex minUtxo fees
-            >>= Right . balanceNonAdaOuts ownPkh utxoIndex
-            >>= Right . addLovelaces minUtxo
-            >>= addSignatories ownPkh privKeys (Map.keys (unBalancedTxRequiredSignatories tx))
+      lift $ printLog Debug $ show utxoIndex
+
+      hoistEither $ preBalanceTx minUtxo fees utxoIndex ownPkh privKeys requiredSigs tx'
+
+preBalanceTx ::
+  Integer ->
+  Integer ->
+  Map TxOutRef TxOut ->
+  PubKeyHash ->
+  Map PubKeyHash PrivateKey ->
+  [PubKeyHash] ->
+  Tx ->
+  Either Text Tx
+preBalanceTx minUtxo fees utxos ownPkh privKeys requiredSigs tx =
+  addTxCollaterals utxos tx
+    >>= balanceTxIns utxos fees
+    >>= balanceNonAdaOuts ownPkh utxos
+    >>= Right . addLovelaces minUtxo
+    >>= balanceTxIns utxos fees -- Adding more inputs if required
+    >>= addSignatories ownPkh privKeys requiredSigs
 
 -- | Getting the necessary utxos to cover the fees for the transaction
 collectTxIns :: Set TxIn -> Map TxOutRef TxOut -> Value -> Either Text (Set TxIn)
-collectTxIns txIns utxos value =
-  if isSufficient inputs
-    then Right inputs
+collectTxIns originalTxIns utxos value =
+  if isSufficient updatedInputs
+    then Right updatedInputs
     else
       Left $
         Text.unlines
           [ "Insufficient tx inputs, needed: "
           , showText (Value.flattenValue value)
           , "got:"
-          , showText (Value.flattenValue (txInsValue inputs))
+          , showText (Value.flattenValue (txInsValue updatedInputs))
           ]
   where
-    inputs = txIns <> otherInputs
-
-    otherInputs =
+    updatedInputs =
       foldl
         ( \acc txIn ->
             if isSufficient acc
               then acc
               else Set.insert txIn acc
         )
-        Set.empty
-        $ filter (not . (`Set.member` txIns)) $
-          mapMaybe (rightToMaybe . txOutToTxIn) $ Map.toList utxos
+        originalTxIns
+        $ mapMaybe (rightToMaybe . txOutToTxIn) $ Map.toList utxos
 
     isSufficient :: Set TxIn -> Bool
     isSufficient txIns' =
-      txInsValue (txIns <> txIns') `Value.geq` value
+      txInsValue txIns' `Value.geq` value
 
     txInsValue :: Set TxIn -> Value
     txInsValue txIns' =
@@ -135,18 +147,17 @@ addLovelaces minLovelaces tx =
           $ txOutputs tx
    in tx {txOutputs = lovelacesAdded}
 
-balanceTxIns :: Map TxOutRef TxOut -> Integer -> Integer -> Tx -> Either Text Tx
-balanceTxIns utxos minLovelaces fees tx = do
+balanceTxIns :: Map TxOutRef TxOut -> Integer -> Tx -> Either Text Tx
+balanceTxIns utxos fees tx = do
   let txOuts = Tx.txOutputs tx
       nonMintedValue = mconcat (map Tx.txOutValue txOuts) `minus` txMint tx
       minSpending =
         mconcat
-          [ Ada.lovelaceValueOf (minLovelaces * fromIntegral (length txOuts))
-          , Ada.lovelaceValueOf fees
+          [ Ada.lovelaceValueOf fees
           , nonMintedValue
           ]
   txIns <- collectTxIns (txInputs tx) utxos minSpending
-  pure $ tx {txInputs = txIns}
+  pure $ tx {txInputs = txIns <> txInputs tx}
 
 {- | Pick a collateral from the utxo map and add it to the unbalanced transaction
  (suboptimally we just pick a random utxo from the tx inputs)
@@ -164,7 +175,7 @@ addTxCollaterals utxos tx = do
       _ -> Left "There are no utxos to be used as collateral"
 
 -- | We need to balance non ada values, as the cardano-cli is unable to balance them (as of 2021/09/24)
-balanceNonAdaOuts :: PubKeyHash -> Map TxOutRef TxOut -> Tx -> Tx
+balanceNonAdaOuts :: PubKeyHash -> Map TxOutRef TxOut -> Tx -> Either Text Tx
 balanceNonAdaOuts ownPkh utxos tx =
   let changeAddr = Ledger.pubKeyHashAddress ownPkh
       txInRefs = map Tx.txInRef $ Set.toList $ txInputs tx
@@ -183,9 +194,9 @@ balanceNonAdaOuts ownPkh utxos tx =
             txOuts
           (txOut@TxOut {txOutValue = v} : txOuts, txOuts') ->
             txOut {txOutValue = v <> nonAdaChange} : (txOuts <> txOuts')
-   in if Value.isZero nonAdaChange
-        then tx
-        else tx {txOutputs = outputs}
+   in if isValueNat nonAdaChange
+        then if Value.isZero nonAdaChange then Right tx else Right $ tx {txOutputs = outputs}
+        else Left "Not enough inputs to balance tokens."
 
 {- | Add the required signatorioes to the transaction. Be aware the the signature itself is invalid,
  and will be ignored. Only the pub key hashes are used, mapped to signing key files on disk.
@@ -220,3 +231,7 @@ minus x y =
 unflattenValue :: (CurrencySymbol, TokenName, Integer) -> Value
 unflattenValue (curSymbol, tokenName, amount) =
   Value.assetClassValue (Value.assetClass curSymbol tokenName) amount
+
+isValueNat :: Value -> Bool
+isValueNat =
+  all (\(_, _, a) -> a >= 0) . Value.flattenValue

--- a/src/MLabsPAB/Server.hs
+++ b/src/MLabsPAB/Server.hs
@@ -141,9 +141,6 @@ handleContract pabConf wallet state contract = liftIO $ do
           { cePABConfig = pabConf
           , ceWallet = wallet
           , ceContractInstanceId = contractInstanceID
-          , ceMinLovelaces = 45
-          , -- Fees are added by the cli, but we need to include enought tx inputs to cover these fees
-            ceFees = 70921796
           , ceOwnPubKey = "5842d469074913a4a0e8e3ec3b4d46eded2076c186735135d1f5e6ef592984d7"
           }
   void $

--- a/src/MLabsPAB/Types.hs
+++ b/src/MLabsPAB/Types.hs
@@ -49,10 +49,6 @@ data ContractEnvironment = ContractEnvironment
   , ceWallet :: Wallet
   , -- | TODO: We should get this from the wallet, once the integration works
     ceOwnPubKey :: PubKey
-  , -- | TODO: We should be able to calculate this
-    ceFees :: Integer
-  , -- | TODO: We should be able to calculate this
-    ceMinLovelaces :: Integer
   }
   deriving stock (Show, Eq)
 

--- a/src/MLabsPAB/UtxoParser.hs
+++ b/src/MLabsPAB/UtxoParser.hs
@@ -1,5 +1,6 @@
 module MLabsPAB.UtxoParser (
   chainIndexTxOutParser,
+  feeParser,
   utxoParser,
   utxoMapParser,
 ) where
@@ -120,3 +121,12 @@ datumHashParser = do
 decodeHash :: Parser Text -> Parser BuiltinByteString
 decodeHash rawParser =
   rawParser >>= \parsed -> either (const mzero) (pure . toBuiltin) (tryDecode parsed)
+
+feeParser :: Parser Integer
+feeParser =
+  choice [prefixed, suffixed]
+  where
+    prefixed =
+      void "Lovelace" *> skipSpace *> signed decimal
+    suffixed =
+      signed decimal <* skipSpace <* void "Lovelace"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,6 +1,7 @@
 module Main (main) where
 
 import Spec.MLabsPAB.Contract qualified
+import Spec.MLabsPAB.PreBalance qualified
 import Spec.MLabsPAB.UtxoParser qualified
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Prelude
@@ -19,4 +20,5 @@ tests =
     "MLabsPAB"
     [ Spec.MLabsPAB.Contract.tests
     , Spec.MLabsPAB.UtxoParser.tests
+    , Spec.MLabsPAB.PreBalance.tests
     ]

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -80,6 +80,26 @@ sendAda = do
             --mainnet
            |]
       , [text|
+            cardano-cli transaction calculate-min-required-utxo --alonzo-era
+            --tx-out ${addr2}+1000
+            --protocol-params-file ./protocol.json
+          |]
+      , [text|
+            cardano-cli transaction build-raw --alonzo-era
+            --tx-out ${addr2}+1000
+            --fee 0
+            --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
+          |]
+      , [text|
+            cardano-cli transaction calculate-min-fee
+            --tx-body-file tx.raw
+            --tx-in-count 1
+            --tx-out-count 1
+            --witness-count 1
+            --protocol-params-file ./protocol.json
+            --mainnet
+          |]
+      , [text|
             cardano-cli transaction build --alonzo-era
             --tx-in ${txId}#0
             --tx-in-collateral ${txId}#0
@@ -113,12 +133,16 @@ multisigSupport = do
       (result, state, _) = runContractPure contract initState
   -- Building and siging the tx includes both signing keys
   result @?= Right ()
-  state.commandHistory
+  drop 3 state.commandHistory
     @?= map
       (Text.replace "\n" " ")
       [ [text|
-          cardano-cli query utxo
-          --address ${addr1}
+          cardano-cli transaction calculate-min-fee
+          --tx-body-file tx.raw
+          --tx-in-count 1
+          --tx-out-count 1
+          --witness-count 2
+          --protocol-params-file ./protocol.json
           --mainnet
           |]
       , [text|
@@ -162,7 +186,7 @@ sendTokens = do
       (result, state, _) = runContractPure contract initState
 
   result @?= Right ()
-  (state.commandHistory !! 1)
+  (state.commandHistory !! 4)
     @?= Text.replace
       "\n"
       " "
@@ -199,7 +223,7 @@ sendTokensWithoutName = do
       (result, state, _) = runContractPure contract initState
 
   result @?= Right ()
-  (state.commandHistory !! 1)
+  (state.commandHistory !! 4)
     @?= Text.replace
       "\n"
       " "
@@ -250,7 +274,7 @@ mintTokens = do
       (result, state, _) = runContractPure contract initState
 
   result @?= Right ()
-  (state.commandHistory !! 1)
+  (state.commandHistory !! 4)
     @?= Text.replace
       "\n"
       " "
@@ -327,7 +351,7 @@ redeemFromValidator = do
       (result, state, _) = runContractPure contract initState
 
   result @?= Right ()
-  (state.commandHistory !! 1)
+  (state.commandHistory !! 4)
     @?= Text.replace
       "\n"
       " "

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -276,6 +276,24 @@ mintTokens = do
       (result, state, _) = runContractPure contract initState
 
   result @?= Right ()
+
+  (state.commandHistory !! 2)
+    @?= Text.replace
+      "\n"
+      " "
+      [text| cardano-cli transaction build-raw --alonzo-era
+       --tx-in ${txId}#0
+       --tx-in-collateral ${txId}#0
+       --tx-out ${addr2}+1000 + 5 ${curSymbol'}.testToken
+       --mint-script-file result-scripts/policy-${curSymbol'}.plutus
+       --mint-redeemer-file result-scripts/redeemer-${redeemerHash}.json
+       --mint-execution-units (297830,1100)
+       --mint 5 ${curSymbol'}.testToken
+       --required-signer signing-keys/signing-key-${pkh1'}.skey
+       --fee 0
+       --protocol-params-file ./protocol.json --out-file tx.raw
+      |]
+
   (state.commandHistory !! 4)
     @?= Text.replace
       "\n"
@@ -353,6 +371,23 @@ redeemFromValidator = do
       (result, state, _) = runContractPure contract initState
 
   result @?= Right ()
+
+  (state.commandHistory !! 2)
+    @?= Text.replace
+      "\n"
+      " "
+      [text| cardano-cli transaction build-raw --alonzo-era
+       --tx-in ${txId}#1
+       --tx-in-script-file result-scripts/validator-${valHash'}.plutus
+       --tx-in-datum-file result-scripts/datum-${datumHash'}.json
+       --tx-in-redeemer-file result-scripts/redeemer-${redeemerHash}.json
+       --tx-in-execution-units (387149,1400)
+       --tx-in-collateral ${txId}#0
+       --tx-out ${addr2}+500
+       --required-signer signing-keys/signing-key-${pkh1'}.skey
+       --fee 0 --protocol-params-file ./protocol.json --out-file tx.raw
+      |]
+
   (state.commandHistory !! 4)
     @?= Text.replace
       "\n"
@@ -368,6 +403,7 @@ redeemFromValidator = do
        --change-address ${addr1}
        --mainnet --protocol-params-file ./protocol.json --out-file tx.raw
       |]
+
   assertFiles
     state
     [ [text|result-scripts/datum-${datumHash'}.json|]

--- a/test/Spec/MLabsPAB/PreBalance.hs
+++ b/test/Spec/MLabsPAB/PreBalance.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Spec.MLabsPAB.PreBalance (tests) where
+
+import Data.Map qualified as Map
+import Data.Set qualified as Set
+import Ledger qualified
+import Ledger.Ada qualified as Ada
+import Ledger.Address (Address)
+import Ledger.Crypto ( PubKeyHash, privateKey1)
+import Ledger.Tx (Tx (..), TxIn (..), TxInType (..), TxOut (..), TxOutRef (..))
+import Ledger.Value qualified as Value
+import MLabsPAB.PreBalance qualified as PreBalance
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (Assertion, testCase, (@?=))
+import Test.Tasty.QuickCheck (Property, testProperty, (===))
+import Wallet (defaultSlotRange)
+import Wallet.Emulator.Types qualified as Wallet
+import Prelude
+
+{- | Tests for 'cardano-cli query utxo' result parsers
+
+ @since 0.1
+-}
+tests :: TestTree
+tests =
+  testGroup
+    "MLabsPAB.UtxoParser"
+    [ testCase "Add utxos to cover fees" addUtxosForFees
+    , testCase "Add utxos to cover native tokens" addUtxosForNativeTokens
+    , testProperty "Double pre balancing does not change the result" prop_DoublePreBalancing
+    ]
+
+
+pkh1, pkh2 :: PubKeyHash
+pkh1 = Ledger.pubKeyHash $ Wallet.walletPubKey (Wallet.knownWallet 1)
+pkh2 = Ledger.pubKeyHash $ Wallet.walletPubKey (Wallet.knownWallet 2)
+
+addr1, addr2 :: Address
+addr1 = Ledger.pubKeyHashAddress pkh1
+addr2 = Ledger.pubKeyHashAddress pkh2
+
+txOutRef1, txOutRef2, txOutRef3, txOutRef4 :: TxOutRef
+txOutRef1 = TxOutRef "384de3f29396fdf687551e3f9e05bd400adcd277720c71f1d2b61f17f5183e51" 0
+txOutRef2 = TxOutRef "52a003b3f4956433429631afe4002f82a924a5a7a891db7ae1f6434797a57dff" 1
+txOutRef3 = TxOutRef "d8a5630a9d7e913f9d186c95e5138a239a4e79ece3414ac894dbf37280944de3" 0
+txOutRef4 = TxOutRef "d8a5630a9d7e913f9d186c95e5138a239a4e79ece3414ac894dbf37280944de3" 2
+
+txIn1, txIn2, txIn3, txIn4 :: TxIn
+txIn1 = TxIn txOutRef1 (Just ConsumePublicKeyAddress)
+txIn2 = TxIn txOutRef2 (Just ConsumePublicKeyAddress)
+txIn3 = TxIn txOutRef3 (Just ConsumePublicKeyAddress)
+txIn4 = TxIn txOutRef4 (Just ConsumePublicKeyAddress)
+
+utxo1, utxo2, utxo3, utxo4 :: (TxOutRef, TxOut)
+utxo1 = (txOutRef1, TxOut addr1 (Ada.lovelaceValueOf 1_100_000) Nothing)
+utxo2 = (txOutRef2, TxOut addr1 (Ada.lovelaceValueOf 1_000_000) Nothing)
+utxo3 = (txOutRef3, TxOut addr1 (Ada.lovelaceValueOf 900_000) Nothing)
+utxo4 = (txOutRef4, TxOut addr1 (Ada.lovelaceValueOf 800_000 <> Value.singleton "11223344" "Token" 200) Nothing)
+
+addUtxosForFees :: Assertion
+addUtxosForFees = do
+  let tx =
+        Tx
+          { txInputs = mempty
+          , txCollateral = mempty
+          , txOutputs = [TxOut addr2 (Ada.lovelaceValueOf 1_000_000) Nothing]
+          , txMint = mempty
+          , txFee = mempty
+          , txValidRange = defaultSlotRange
+          , txMintScripts = mempty
+          , txSignatures = mempty
+          , txRedeemers = mempty
+          , txData = mempty
+          }
+  let minUtxo = 1_000_000
+      fees = 500_000
+      utxoIndex = Map.fromList [utxo1, utxo2, utxo3]
+      privKeys = Map.fromList [(pkh1, privateKey1)]
+      requiredSigs = [pkh1]
+      ownPkh = pkh1
+      prebalancedTx = PreBalance.preBalanceTx minUtxo fees utxoIndex ownPkh privKeys requiredSigs tx
+
+  txInputs <$> prebalancedTx @?= Right (Set.fromList [txIn1, txIn2])
+
+addUtxosForNativeTokens :: Assertion
+addUtxosForNativeTokens = do
+  let tx =
+        Tx
+          { txInputs = mempty
+          , txCollateral = mempty
+          , txOutputs = [TxOut addr2 (Value.singleton "11223344" "Token" 123) Nothing]
+          , txMint = mempty
+          , txFee = mempty
+          , txValidRange = defaultSlotRange
+          , txMintScripts = mempty
+          , txSignatures = mempty
+          , txRedeemers = mempty
+          , txData = mempty
+          }
+  let minUtxo = 1_000_000
+      fees = 500_000
+      utxoIndex = Map.fromList [utxo1, utxo2, utxo3, utxo4]
+      privKeys = Map.fromList [(pkh1, privateKey1)]
+      requiredSigs = [pkh1]
+      ownPkh = pkh1
+      prebalancedTx = PreBalance.preBalanceTx minUtxo fees utxoIndex ownPkh privKeys requiredSigs tx
+
+  txInputs <$> prebalancedTx @?= Right (Set.fromList [txIn1, txIn2, txIn3, txIn4])
+
+prop_DoublePreBalancing :: Tx -> Property
+prop_DoublePreBalancing tx =
+  let minUtxo = 1_000_000
+      fees = 500_000
+      utxoIndex = Map.fromList [utxo1, utxo2, utxo3, utxo4]
+      privKeys = Map.fromList [(pkh1, privateKey1)]
+      requiredSigs = [pkh1]
+      ownPkh = pkh1
+   in PreBalance.preBalanceTx minUtxo fees utxoIndex ownPkh privKeys requiredSigs tx
+        === ( PreBalance.preBalanceTx minUtxo fees utxoIndex ownPkh privKeys requiredSigs tx
+                >>= PreBalance.preBalanceTx minUtxo fees utxoIndex ownPkh privKeys requiredSigs
+            )

--- a/test/Spec/MLabsPAB/PreBalance.hs
+++ b/test/Spec/MLabsPAB/PreBalance.hs
@@ -9,7 +9,7 @@ import Data.Set qualified as Set
 import Ledger qualified
 import Ledger.Ada qualified as Ada
 import Ledger.Address (Address)
-import Ledger.Crypto ( PubKeyHash, privateKey1)
+import Ledger.Crypto (PubKeyHash, privateKey1)
 import Ledger.Tx (Tx (..), TxIn (..), TxInType (..), TxOut (..), TxOutRef (..))
 import Ledger.Value qualified as Value
 import MLabsPAB.PreBalance qualified as PreBalance
@@ -32,7 +32,6 @@ tests =
     , testCase "Add utxos to cover native tokens" addUtxosForNativeTokens
     , testProperty "Double pre balancing does not change the result" prop_DoublePreBalancing
     ]
-
 
 pkh1, pkh2 :: PubKeyHash
 pkh1 = Ledger.pubKeyHash $ Wallet.walletPubKey (Wallet.knownWallet 1)

--- a/test/Spec/MLabsPAB/PreBalance.hs
+++ b/test/Spec/MLabsPAB/PreBalance.hs
@@ -1,7 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-{-# LANGUAGE QuasiQuotes #-}
-{-# LANGUAGE TemplateHaskell #-}
-
 module Spec.MLabsPAB.PreBalance (tests) where
 
 import Data.Map qualified as Map

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -149,8 +149,6 @@ instance Default ContractEnvironment where
       , ceContractInstanceId = ContractInstanceId UUID.nil
       , ceWallet = knownWallet 1
       , ceOwnPubKey = pubKey1
-      , ceFees = 200
-      , ceMinLovelaces = 50
       }
 type MockContract a = Eff '[Error Text, State MockContractState, Writer [String]] a
 
@@ -211,6 +209,12 @@ mockCallCommand ShellArgs {cmdName, cmdArgs, cmdOutParser} = do
       cmdOutParser <$> mockQueryUtxo addr
     ("cardano-cli", "transaction" : "build" : _) ->
       pure $ cmdOutParser ""
+    ("cardano-cli", "transaction" : "build-raw" : _) ->
+      pure $ cmdOutParser ""
+    ("cardano-cli", "transaction" : "calculate-min-required-utxo" : _) ->
+      pure $ cmdOutParser "Lovelace 50"
+    ("cardano-cli", "transaction" : "calculate-min-fee" : _) ->
+      pure $ cmdOutParser "200 Lovelace"
     ("cardano-cli", "transaction" : "sign" : _) ->
       pure $ cmdOutParser ""
     ("cardano-cli", "transaction" : "submit" : _) ->


### PR DESCRIPTION
Solves: #10

I tried to reuse functions from the cardano-node repository, but had a few problems getting the required values for the computation (namely EraHistory and SystemStart), so I decided to use the CLI for this.

I had to add the following steps to the tx submit flow:
1. calculating minimum utxo
2. build a tx with build-raw, this doesnt include any fees yet, its only purpose is to be used in the following step
3. calculate minimum fees, this uses a tx file as its input

For the second step, I had to use the raw transaction build mode, so the cli wouldn't worry about balancing, and would create a tx even if there aren't enough inputs. However, I had to introduce execution unit calculation, which is needed by the cli in raw mode.