### PR TITLE
Add Writer implementation

### DIFF
--- a/mlabs-pab.cabal
+++ b/mlabs-pab.cabal
@@ -177,6 +177,7 @@ test-suite mlabs-pab-test
     , quickcheck-instances
     , row-types
     , serialise
+    , stm
     , tasty
     , tasty-hunit
     , tasty-quickcheck

--- a/src/MLabsPAB/CardanoCLI.hs
+++ b/src/MLabsPAB/CardanoCLI.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
 module MLabsPAB.CardanoCLI (
@@ -80,26 +81,26 @@ import Prelude
 
 -- | Upload script files to remote server
 uploadFiles ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   Eff effs ()
 uploadFiles pabConf =
   mapM_
-    uploadDir
+    (uploadDir @w)
     [ pabConf.pcScriptFileDir
     , pabConf.pcSigningKeyFileDir
     ]
 
 -- | Getting all available UTXOs at an address (all utxos are assumed to be PublicKeyChainIndexTxOut)
 utxosAt ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   Address ->
   Eff effs (Map TxOutRef ChainIndexTxOut)
 utxosAt pabConf address =
-  callCommand
+  callCommand @w
     ShellArgs
       { cmdName = "cardano-cli"
       , cmdArgs =
@@ -116,13 +117,13 @@ utxosAt pabConf address =
       }
 
 calculateMinUtxo ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   UnbalancedTx ->
   Eff effs (Either Text Integer)
 calculateMinUtxo pabConf UnbalancedTx {unBalancedTxTx} =
-  callCommand
+  callCommand @w
     ShellArgs
       { cmdName = "cardano-cli"
       , cmdArgs =
@@ -136,13 +137,13 @@ calculateMinUtxo pabConf UnbalancedTx {unBalancedTxTx} =
 
 -- | Calculating fee for an unbalanced transaction
 calculateMinFee ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   Tx ->
   Eff effs (Either Text Integer)
 calculateMinFee pabConf tx =
-  callCommand
+  callCommand @w
     ShellArgs
       { cmdName = "cardano-cli"
       , cmdArgs =
@@ -169,15 +170,15 @@ isRawBuildMode _ = False
  If a fee if specified, it uses the build-raw command
 -}
 buildTx ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   PubKeyHash ->
   BuildMode ->
   Tx ->
   Eff effs ()
 buildTx pabConf ownPkh buildMode tx =
-  callCommand $ ShellArgs "cardano-cli" opts (const ())
+  callCommand @w $ ShellArgs "cardano-cli" opts (const ())
   where
     ownAddr = Ledger.pubKeyHashAddress ownPkh
     requiredSigners =
@@ -207,14 +208,14 @@ buildTx pabConf ownPkh buildMode tx =
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
 signTx ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   Tx ->
   [PubKey] ->
   Eff effs ()
 signTx pabConf tx pubKeys =
-  callCommand $
+  callCommand @w $
     ShellArgs
       "cardano-cli"
       ( mconcat
@@ -233,13 +234,13 @@ signTx pabConf tx pubKeys =
 
 -- Signs and writes a tx (uses the tx body written to disk as input)
 submitTx ::
-  forall (effs :: [Type -> Type]).
-  Member PABEffect effs =>
+  forall (w :: Type) (effs :: [Type -> Type]).
+  Member (PABEffect w) effs =>
   PABConfig ->
   Tx ->
   Eff effs (Maybe Text)
 submitTx pabConf tx =
-  callCommand $
+  callCommand @w $
     ShellArgs
       "cardano-cli"
       ( mconcat

--- a/src/MLabsPAB/Server.hs
+++ b/src/MLabsPAB/Server.hs
@@ -111,7 +111,6 @@ subscribeToContract conn (AppState s) contractInstanceID =
         guard (not (null msgs))
         pure (result, msgs)
 
-      mapM_ print msgs
       mapM_ (sendTextData conn . JSON.encode) msgs
 
       unless (isFinished lastStatus) $ observeUpdates contractState (Just lastStatus)

--- a/src/MLabsPAB/Server.hs
+++ b/src/MLabsPAB/Server.hs
@@ -3,7 +3,7 @@
 module MLabsPAB.Server (app, initState) where
 
 import Control.Concurrent (ThreadId, forkIO)
-import Control.Concurrent.STM (atomically, modifyTVar, newTVarIO, readTVar, retry)
+import Control.Concurrent.STM (TVar, atomically, modifyTVar, newTVarIO, readTVar, readTVarIO, retry)
 import Control.Monad (forever, guard, unless, void)
 import Control.Monad.IO.Class (liftIO)
 import Data.Aeson (FromJSON, ToJSON (toJSON))
@@ -11,11 +11,18 @@ import Data.Aeson qualified as JSON
 import Data.Either.Combinators (leftToMaybe)
 import Data.Kind (Type)
 import Data.Map qualified as Map
-import Data.Maybe (fromMaybe)
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Proxy (Proxy (Proxy))
+import Data.Row (Row)
 import Data.UUID.V4 qualified as UUID
 import MLabsPAB.Contract (runContract)
-import MLabsPAB.Types (ContractEnvironment (..), ContractState (ContractState), PABConfig)
+import MLabsPAB.Types (
+  AppState (AppState),
+  ContractEnvironment (..),
+  ContractState (ContractState),
+  PABConfig,
+  SomeContractState (SomeContractState),
+ )
 import Network.WebSockets (
   Connection,
   PendingConnection,
@@ -25,12 +32,18 @@ import Network.WebSockets (
   withPingThread,
  )
 import Plutus.Contract.Types (IsContract (toContract))
-import Plutus.PAB.Effects.Contract.Builtin (ContractConstraints, HasDefinitions, SomeBuiltin (..), getContract)
+import Plutus.PAB.Core.ContractInstance.STM (Activity (Active, Done))
+import Plutus.PAB.Effects.Contract.Builtin (
+  ContractConstraints,
+  HasDefinitions,
+  SomeBuiltin (..),
+  getContract,
+ )
 import Plutus.PAB.Webserver.Types (
   CombinedWSStreamToClient (InstanceUpdate),
   CombinedWSStreamToServer (Subscribe),
   ContractActivationArgs (..),
-  InstanceStatusToClient (ContractFinished),
+  InstanceStatusToClient (ContractFinished, NewObservableState),
  )
 import Servant.API (JSON, Post, ReqBody, (:<|>) (..), (:>))
 import Servant.API.WebSocket (WebSocketPending)
@@ -39,8 +52,8 @@ import Wallet.Emulator (Wallet, knownWallet)
 import Wallet.Types (ContractInstanceId (..))
 import Prelude
 
-initState :: IO ContractState
-initState = ContractState <$> newTVarIO Map.empty
+initState :: IO AppState
+initState = AppState <$> newTVarIO Map.empty
 
 -- | Mock API Schema, stripped endpoints that we don't use in this project
 type API a =
@@ -52,18 +65,18 @@ type API a =
             :> Post '[JSON] ContractInstanceId -- Start a new instance.
          )
 
-server :: HasDefinitions t => PABConfig -> ContractState -> Server (API t)
+server :: HasDefinitions t => PABConfig -> AppState -> Server (API t)
 server pabConfig state =
   websocketHandler state :<|> activateContractHandler pabConfig state
 
 apiProxy :: forall (t :: Type). Proxy (API t)
 apiProxy = Proxy
 
-app :: forall (t :: Type). (HasDefinitions t, FromJSON t) => PABConfig -> ContractState -> Application
+app :: forall (t :: Type). (HasDefinitions t, FromJSON t) => PABConfig -> AppState -> Application
 app pabConfig state = serve (apiProxy @t) $ server pabConfig state
 
 -- | Mock websocket handler (can only send ContractFinished message)
-websocketHandler :: ContractState -> PendingConnection -> Handler ()
+websocketHandler :: AppState -> PendingConnection -> Handler ()
 websocketHandler state pendingConn = liftIO $ do
   conn <- acceptRequest pendingConn
 
@@ -79,41 +92,84 @@ websocketHandler state pendingConn = liftIO $ do
 {- | Create a thread subscribing to state changes on a specific contract instance
  and send a websocket response on each change
 -}
-subscribeToContract :: Connection -> ContractState -> ContractInstanceId -> IO ThreadId
-subscribeToContract conn (ContractState s) contractInstanceID =
+subscribeToContract :: Connection -> AppState -> ContractInstanceId -> IO ThreadId
+subscribeToContract conn (AppState s) contractInstanceID =
   forkIO $ do
     putStrLn $ "WebSocket subscribed to " ++ show contractInstanceID
-    observeUpdates Nothing
+    SomeContractState contractState <- atomically $ do
+      instances <- readTVar s
+      maybe retry pure $ Map.lookup contractInstanceID instances
+    observeUpdates contractState Nothing
   where
-    observeUpdates prevHandled = do
+    observeUpdates :: forall (w :: Type). ToJSON w => TVar (ContractState w) -> Maybe (ContractState w) -> IO ()
+    observeUpdates contractState prevHandled = do
       statusUpdate <- atomically $ do
-        finishedInstances <- readTVar s
+        result <- readTVar contractState
 
-        case Map.lookup contractInstanceID finishedInstances of
-          Just result -> do
-            guard (Just result /= prevHandled)
-            pure result
-          Nothing -> retry
+        let msgs = handleContractActivityChange contractInstanceID prevHandled result
+        guard (not (null msgs))
+        pure result
 
-      let msg = InstanceUpdate contractInstanceID statusUpdate
-      sendTextData conn $ JSON.encode msg
+      mapM_ (sendTextData conn . JSON.encode) $
+        handleContractActivityChange contractInstanceID prevHandled statusUpdate
 
-      unless (isFinished statusUpdate) $ observeUpdates (Just statusUpdate)
+      unless (isFinished statusUpdate) $ observeUpdates contractState (Just statusUpdate)
 
-    isFinished (ContractFinished _) = True
+    isFinished (ContractState (Done _) _) = True
     isFinished _ = False
 
+-- | Detects changes between states and composes the messages to be sent via the websocket channel
+handleContractActivityChange ::
+  forall (w :: Type).
+  ToJSON w =>
+  ContractInstanceId ->
+  Maybe (ContractState w) ->
+  ContractState w ->
+  [CombinedWSStreamToClient]
+handleContractActivityChange
+  contractInstanceID
+  (Just (ContractState prevA prevW))
+  (ContractState a w) =
+    catMaybes [activityChange, observableStateChange]
+    where
+      activityChange =
+        if prevA /= a
+          then case a of
+            Done maybeError -> do
+              Just $ InstanceUpdate contractInstanceID $ ContractFinished maybeError
+            _ -> Nothing
+          else Nothing
+
+      observableStateChange =
+        if toJSON prevW /= toJSON w
+          then Just $ InstanceUpdate contractInstanceID $ NewObservableState (toJSON w)
+          else Nothing
+handleContractActivityChange _ _ _ = []
+
 -- | Broadcast a contract update to subscribers
-broadcastContractResult :: ContractState -> ContractInstanceId -> InstanceStatusToClient -> IO ()
-broadcastContractResult (ContractState s) contractInstanceID statusUpdateMsg =
-  atomically $
-    modifyTVar s $ Map.insert contractInstanceID statusUpdateMsg
+broadcastContractResult ::
+  forall (w :: Type).
+  (Monoid w, ToJSON w) =>
+  AppState ->
+  ContractInstanceId ->
+  Maybe JSON.Value ->
+  IO ()
+broadcastContractResult (AppState st) contractInstanceID maybeError = do
+  state <- readTVarIO st
+  case Map.lookup contractInstanceID state of
+    Nothing -> do
+      contractState <- newTVarIO $ ContractState (Done maybeError) (mempty :: w)
+      atomically $ modifyTVar st (Map.insert contractInstanceID (SomeContractState contractState))
+    Just (SomeContractState cs) -> atomically $
+      modifyTVar cs $ \(ContractState _ w) ->
+        ContractState (Done maybeError) w
 
 -- | This handler will call the corresponding contract endpoint handler
 activateContractHandler ::
+  forall (c :: Type).
   HasDefinitions c =>
   PABConfig ->
-  ContractState ->
+  AppState ->
   ContractActivationArgs c ->
   Handler ContractInstanceId
 activateContractHandler pabConf state (ContractActivationArgs cardMessage maybeWallet) =
@@ -122,21 +178,30 @@ activateContractHandler pabConf state (ContractActivationArgs cardMessage maybeW
         SomeBuiltin contract -> handleContract pabConf wallet state contract
 
 handleContract ::
-  forall w s e a contract.
+  forall
+    (w :: Type)
+    (s :: Row Type)
+    (e :: Type)
+    (a :: Type)
+    (contract :: Type -> Row Type -> Type -> Type -> Type).
   ( ContractConstraints w s e
   , IsContract contract
   ) =>
   PABConfig ->
   Wallet ->
-  ContractState ->
+  AppState ->
   contract w s e a ->
   Handler ContractInstanceId
-handleContract pabConf wallet state contract = liftIO $ do
+handleContract pabConf wallet state@(AppState st) contract = liftIO $ do
   contractInstanceID <- liftIO $ ContractInstanceId <$> UUID.nextRandom
+  contractState <- newTVarIO (ContractState Active mempty)
+
+  atomically $ modifyTVar st (Map.insert contractInstanceID (SomeContractState contractState))
+
   let contractEnv =
         ContractEnvironment
           { cePABConfig = pabConf
-          , ceContractState = state
+          , ceContractState = contractState
           , ceWallet = wallet
           , ceContractInstanceId = contractInstanceID
           , ceOwnPubKey = "5842d469074913a4a0e8e3ec3b4d46eded2076c186735135d1f5e6ef592984d7"
@@ -144,6 +209,6 @@ handleContract pabConf wallet state contract = liftIO $ do
   void $
     forkIO $ do
       result <- runContract contractEnv wallet (toContract contract)
-      let updateMsg = ContractFinished (toJSON <$> leftToMaybe result)
-      broadcastContractResult state contractInstanceID updateMsg
+      let maybeError = toJSON <$> leftToMaybe result
+      broadcastContractResult @w state contractInstanceID maybeError
   pure contractInstanceID

--- a/src/MLabsPAB/Types.hs
+++ b/src/MLabsPAB/Types.hs
@@ -1,6 +1,7 @@
 module MLabsPAB.Types (
   PABConfig (..),
   CLILocation (..),
+  ContractState (ContractState),
   LogLevel (..),
   ContractEnvironment (..),
   HasDefinitions (..),
@@ -10,7 +11,9 @@ module MLabsPAB.Types (
 
 import Cardano.Api (NetworkId (Testnet), NetworkMagic (..))
 import Cardano.Api.Shelley (ProtocolParameters)
+import Control.Concurrent.STM (TVar)
 import Data.Default (Default (def))
+import Data.Map (Map)
 import Data.Text (Text)
 import Ledger (PubKey)
 import Plutus.PAB.Effects.Contract.Builtin (
@@ -18,6 +21,7 @@ import Plutus.PAB.Effects.Contract.Builtin (
   SomeBuiltin (SomeBuiltin),
   endpointsToSchemas,
  )
+import Plutus.PAB.Webserver.Types (InstanceStatusToClient)
 import Wallet.Emulator (Wallet)
 import Wallet.Types (ContractInstanceId (..))
 import Prelude
@@ -44,11 +48,18 @@ data PABConfig = PABConfig
 data ContractEnvironment = ContractEnvironment
   { cePABConfig :: PABConfig
   , ceContractInstanceId :: ContractInstanceId
+  , ceContractState :: ContractState
   , ceWallet :: Wallet
   , -- | TODO: We should get this from the wallet, once the integration works
     ceOwnPubKey :: PubKey
   }
   deriving stock (Show, Eq)
+
+newtype ContractState = ContractState (TVar (Map ContractInstanceId InstanceStatusToClient))
+  deriving stock (Eq)
+
+instance Show ContractState where
+  show _ = "<ContractState>"
 
 data CLILocation = Local | Remote Text
   deriving stock (Show, Eq)

--- a/src/MLabsPAB/Types.hs
+++ b/src/MLabsPAB/Types.hs
@@ -76,8 +76,8 @@ data SomeContractState
   = forall (w :: Type). (ToJSON w) => SomeContractState (TVar (ContractState w))
 
 data ContractState w = ContractState
-  { cisActivity :: Activity
-  , cisObservableState :: w
+  { csActivity :: Activity
+  , csObservableState :: w
   }
   deriving stock (Show, Eq)
 

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -4,6 +4,7 @@
 module Spec.MLabsPAB.Contract (tests) where
 
 import Control.Lens (ix, (&), (.~), (^.), (^?))
+import Data.Aeson (ToJSON)
 import Data.Aeson.Extras (encodeByteString)
 import Data.Default (def)
 import Data.Kind (Type)
@@ -490,7 +491,7 @@ assertFiles state expectedFiles =
 
 assertContractWithTxId ::
   forall (w :: Type) (s :: Row Type).
-  (Monoid w) =>
+  (ToJSON w) =>
   Contract w s Text CardanoTx ->
   MockContractState ->
   (MockContractState -> Text -> Assertion) ->

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -47,7 +47,6 @@ import Cardano.Api (
  )
 import Cardano.Crypto.DSIGN (genKeyDSIGN)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
-import Plutus.PAB.Core.ContractInstance.STM (Activity (Active))
 import Control.Concurrent.STM (newTVarIO)
 import Control.Lens (at, (%~), (&), (<|), (?~), (^.), (^..), _1)
 import Control.Lens.TH (makeLenses)
@@ -96,6 +95,7 @@ import NeatInterpolation (text)
 import Plutus.ChainIndex.Types (BlockId (..), Tip (..))
 import Plutus.Contract (Contract (Contract))
 import Plutus.Contract.Effects (ChainIndexQuery (..), ChainIndexResponse (..))
+import Plutus.PAB.Core.ContractInstance.STM (Activity (Active))
 import PlutusTx.Builtins (fromBuiltin)
 import System.IO.Unsafe (unsafePerformIO)
 import Wallet.Emulator (knownWallet)
@@ -183,7 +183,7 @@ instance Monoid w => Default (ContractEnvironment w) where
       }
 
 instance Monoid w => Default (ContractState w) where
-  def = ContractState {cisActivity = Active, cisObservableState = mempty }
+  def = ContractState {cisActivity = Active, cisObservableState = mempty}
 
 type MockContract w a = Eff '[Error Text, State (MockContractState w)] a
 

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -87,7 +87,7 @@ import MLabsPAB.Effects (PABEffect (..), ShellArgs (..))
 import MLabsPAB.Files qualified as Files
 import MLabsPAB.Types (
   ContractEnvironment (..),
-  ContractState (ContractState, cisActivity, cisObservableState),
+  ContractState (ContractState, csActivity, csObservableState),
   LogLevel (..),
   PABConfig (..),
  )
@@ -183,7 +183,7 @@ instance Monoid w => Default (ContractEnvironment w) where
       }
 
 instance Monoid w => Default (ContractState w) where
-  def = ContractState {cisActivity = Active, cisObservableState = mempty}
+  def = ContractState {csActivity = Active, csObservableState = mempty}
 
 type MockContract w a = Eff '[Error Text, State (MockContractState w)] a
 

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -26,6 +26,7 @@ module Spec.MockContract (
   instanceUpdateHistory,
   logHistory,
   contractEnv,
+  observableState,
   files,
   tip,
   utxos,
@@ -46,6 +47,7 @@ import Cardano.Api (
  )
 import Cardano.Crypto.DSIGN (genKeyDSIGN)
 import Cardano.Crypto.Seed (mkSeedFromBytes)
+import Plutus.PAB.Core.ContractInstance.STM (Activity (Active))
 import Control.Concurrent.STM (newTVarIO)
 import Control.Lens (at, (%~), (&), (<|), (?~), (^.), (^..), _1)
 import Control.Lens.TH (makeLenses)
@@ -86,7 +88,7 @@ import MLabsPAB.Effects (PABEffect (..), ShellArgs (..))
 import MLabsPAB.Files qualified as Files
 import MLabsPAB.Types (
   ContractEnvironment (..),
-  ContractState (ContractState),
+  ContractState (ContractState, cisActivity, cisObservableState),
   LogLevel (..),
   PABConfig (..),
  )
@@ -94,7 +96,6 @@ import NeatInterpolation (text)
 import Plutus.ChainIndex.Types (BlockId (..), Tip (..))
 import Plutus.Contract (Contract (Contract))
 import Plutus.Contract.Effects (ChainIndexQuery (..), ChainIndexResponse (..))
-import Plutus.PAB.Webserver.Types (InstanceStatusToClient)
 import PlutusTx.Builtins (fromBuiltin)
 import System.IO.Unsafe (unsafePerformIO)
 import Wallet.Emulator (knownWallet)
@@ -141,20 +142,21 @@ data MockFile
   | OtherFile Text
   deriving stock (Show, Eq)
 
-data MockContractState = MockContractState
+data MockContractState w = MockContractState
   { _files :: Map FilePath MockFile
   , _commandHistory :: [Text]
-  , _instanceUpdateHistory :: [InstanceStatusToClient]
+  , _instanceUpdateHistory :: [Activity]
+  , _observableState :: w
   , _logHistory :: [(LogLevel, String)]
-  , _contractEnv :: ContractEnvironment
+  , _contractEnv :: ContractEnvironment w
   , _utxos :: [(TxOutRef, TxOut)]
   , _tip :: Tip
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show)
 
 makeLenses ''MockContractState
 
-instance Default MockContractState where
+instance Monoid w => Default (MockContractState w) where
   def =
     MockContractState
       { _files =
@@ -164,33 +166,37 @@ instance Default MockContractState where
               [signingKey1, signingKey2, signingKey3]
       , _commandHistory = mempty
       , _instanceUpdateHistory = mempty
+      , _observableState = mempty
       , _logHistory = mempty
       , _contractEnv = def
       , _utxos = []
       , _tip = Tip 1000 (BlockId "ab12") 4
       }
 
-instance Default ContractEnvironment where
+instance Monoid w => Default (ContractEnvironment w) where
   def =
     ContractEnvironment
       { cePABConfig = def {pcNetwork = Mainnet}
       , ceContractInstanceId = ContractInstanceId UUID.nil
-      , ceContractState = ContractState <$> unsafePerformIO $ newTVarIO Map.empty
+      , ceContractState = unsafePerformIO $ newTVarIO def
       , ceWallet = knownWallet 1
       , ceOwnPubKey = pubKey1
       }
 
-type MockContract a = Eff '[Error Text, State MockContractState] a
+instance Monoid w => Default (ContractState w) where
+  def = ContractState {cisActivity = Active, cisObservableState = mempty }
+
+type MockContract w a = Eff '[Error Text, State (MockContractState w)] a
 
 {- | Run the contract monad in a pure mock runner, and return a tuple of the contract result and
  the contract state
 -}
 runContractPure ::
   forall (w :: Type) (s :: Row Type) (a :: Type).
-  (ToJSON w) =>
+  (ToJSON w, Monoid w) =>
   Contract w s Text a ->
-  MockContractState ->
-  (Either Text a, MockContractState)
+  MockContractState w ->
+  (Either Text a, MockContractState w)
 runContractPure contract initContractState =
   let (res, st) = runContractPure' contract initContractState
    in ( res
@@ -202,29 +208,30 @@ runContractPure contract initContractState =
 
 runContractPure' ::
   forall (w :: Type) (s :: Row Type) (a :: Type).
-  (ToJSON w) =>
+  (ToJSON w, Monoid w) =>
   Contract w s Text a ->
-  MockContractState ->
-  (Either Text a, MockContractState)
+  MockContractState w ->
+  (Either Text a, MockContractState w)
 runContractPure' (Contract effs) initContractState =
   first join $
     runPABEffectPure initContractState $
       handleContract (initContractState ^. contractEnv) effs
 
 runPABEffectPure ::
-  forall (a :: Type).
-  MockContractState ->
-  Eff '[PABEffect] a ->
-  (Either Text a, MockContractState)
+  forall (a :: Type) (w :: Type).
+  MockContractState w ->
+  Eff '[PABEffect w] a ->
+  (Either Text a, MockContractState w)
 runPABEffectPure initState req =
   run (runState initState (runError (reinterpret2 go req)))
   where
-    go :: PABEffect v -> MockContract v
+    go :: forall (v :: Type). PABEffect w v -> MockContract w v
     go (CallCommand args) = mockCallCommand args
     go (CreateDirectoryIfMissing createParents filePath) =
       mockCreateDirectoryIfMissing createParents filePath
     go (PrintLog logLevel msg) = mockPrintLog logLevel msg
     go (UpdateInstanceState msg) = mockUpdateInstanceState msg
+    go (LogToContract msg) = mockLogToContract msg
     go (ThreadDelay microseconds) = mockThreadDelay microseconds
     go (ReadFileTextEnvelope asType filepath) = mockReadFileTextEnvelope asType filepath
     go (WriteFileJSON filepath value) = mockWriteFileJSON filepath value
@@ -235,11 +242,11 @@ runPABEffectPure initState req =
     go (QueryChainIndex query) = mockQueryChainIndex query
 
 mockCallCommand ::
-  forall (a :: Type).
+  forall (w :: Type) (a :: Type).
   ShellArgs a ->
-  MockContract a
+  MockContract w a
 mockCallCommand ShellArgs {cmdName, cmdArgs, cmdOutParser} = do
-  modify (commandHistory %~ (cmdName <> " " <> Text.unwords cmdArgs <|))
+  modify @(MockContractState w) (commandHistory %~ (cmdName <> " " <> Text.unwords cmdArgs <|))
 
   case (cmdName, cmdArgs) of
     ("cardano-cli", "query" : "utxo" : "--address" : addr : _) ->
@@ -251,21 +258,21 @@ mockCallCommand ShellArgs {cmdName, cmdArgs, cmdOutParser} = do
     ("cardano-cli", "transaction" : "build-raw" : args) -> do
       case drop 1 $ dropWhile (/= "--out-file") args of
         filepath : _ ->
-          modify (files . at (Text.unpack filepath) ?~ OtherFile "TxBody")
+          modify @(MockContractState w) (files . at (Text.unpack filepath) ?~ OtherFile "TxBody")
         _ -> throwError @Text "Out file argument is missing"
 
       pure $ cmdOutParser ""
     ("cardano-cli", "transaction" : "build" : args) -> do
       case drop 1 $ dropWhile (/= "--out-file") args of
         filepath : _ ->
-          modify (files . at (Text.unpack filepath) ?~ OtherFile "TxBody")
+          modify @(MockContractState w) (files . at (Text.unpack filepath) ?~ OtherFile "TxBody")
         _ -> throwError @Text "Out file argument is missing"
 
       pure $ cmdOutParser ""
     ("cardano-cli", "transaction" : "sign" : args) -> do
       case drop 1 $ dropWhile (/= "--out-file") args of
         filepath : _ ->
-          modify (files . at (Text.unpack filepath) ?~ OtherFile "Tx")
+          modify @(MockContractState w) (files . at (Text.unpack filepath) ?~ OtherFile "Tx")
         _ -> throwError @Text "Out file argument is missing"
 
       pure $ cmdOutParser ""
@@ -273,9 +280,9 @@ mockCallCommand ShellArgs {cmdName, cmdArgs, cmdOutParser} = do
       pure $ cmdOutParser ""
     _ -> throwError @Text "Unknown command"
 
-mockQueryUtxo :: Text -> MockContract String
+mockQueryUtxo :: forall (w :: Type). Text -> MockContract w String
 mockQueryUtxo addr = do
-  state <- get @MockContractState
+  state <- get @(MockContractState w)
 
   let network = (state ^. contractEnv).cePABConfig.pcNetwork
   pure $
@@ -325,28 +332,32 @@ valueToUtxoOut =
                       else [text|${curSymbol'}.${tokenName'}|]
        in Text.pack (show tAmt) <> " " <> token
 
-mockCreateDirectoryIfMissing :: Bool -> FilePath -> MockContract ()
+mockCreateDirectoryIfMissing :: forall (w :: Type). Bool -> FilePath -> MockContract w ()
 mockCreateDirectoryIfMissing _ _ = pure ()
 
-mockPrintLog :: LogLevel -> String -> MockContract ()
+mockPrintLog :: forall (w :: Type). LogLevel -> String -> MockContract w ()
 mockPrintLog logLevel msg =
-  modify (logHistory %~ ((logLevel, msg) <|))
+  modify @(MockContractState w) (logHistory %~ ((logLevel, msg) <|))
 
-mockUpdateInstanceState :: InstanceStatusToClient -> MockContract ()
+mockUpdateInstanceState :: forall (w :: Type). Activity -> MockContract w ()
 mockUpdateInstanceState msg =
-  modify (instanceUpdateHistory %~ (msg <|))
+  modify @(MockContractState w) (instanceUpdateHistory %~ (msg <|))
 
-mockThreadDelay :: Int -> MockContract ()
+mockLogToContract :: forall (w :: Type). (Monoid w) => w -> MockContract w ()
+mockLogToContract msg =
+  modify (observableState %~ (<> msg))
+
+mockThreadDelay :: forall (w :: Type). Int -> MockContract w ()
 mockThreadDelay _ = pure ()
 
 mockReadFileTextEnvelope ::
-  forall (a :: Type).
+  forall (w :: Type) (a :: Type).
   HasTextEnvelope a =>
   AsType a ->
   FilePath ->
-  MockContract (Either (FileError TextEnvelopeError) a)
+  MockContract w (Either (FileError TextEnvelopeError) a)
 mockReadFileTextEnvelope ttoken filepath = do
-  state <- get @MockContractState
+  state <- get @(MockContractState w)
 
   pure $
     case state ^. files . at filepath of
@@ -355,35 +366,35 @@ mockReadFileTextEnvelope ttoken filepath = do
         mapLeft (FileError filepath) $ deserialiseFromTextEnvelope ttoken te
       Just _ -> Left $ FileError filepath $ TextEnvelopeAesonDecodeError "Invalid format."
 
-mockWriteFileJSON :: FilePath -> JSON.Value -> MockContract (Either (FileError ()) ())
+mockWriteFileJSON :: forall (w :: Type). FilePath -> JSON.Value -> MockContract w (Either (FileError ()) ())
 mockWriteFileJSON filepath value = do
   let fileContent = JsonFile value
-  modify (files . at filepath ?~ fileContent)
+  modify @(MockContractState w) (files . at filepath ?~ fileContent)
 
   pure $ Right ()
 
 mockWriteFileTextEnvelope ::
-  forall (a :: Type).
+  forall (w :: Type) (a :: Type).
   HasTextEnvelope a =>
   FilePath ->
   Maybe TextEnvelopeDescr ->
   a ->
-  MockContract (Either (FileError ()) ())
+  MockContract w (Either (FileError ()) ())
 mockWriteFileTextEnvelope filepath descr content = do
   let fileContent = TextEnvelopeFile (serialiseToTextEnvelope descr content)
-  modify (files . at filepath ?~ fileContent)
+  modify @(MockContractState w) (files . at filepath ?~ fileContent)
 
   pure $ Right ()
 
-mockListDirectory :: FilePath -> MockContract [FilePath]
+mockListDirectory :: forall (w :: Type). FilePath -> MockContract w [FilePath]
 mockListDirectory filepath = do
-  state <- get @MockContractState
+  state <- get @(MockContractState w)
   pure $ map (drop (length filepath + 1)) $ filter (filepath `isPrefixOf`) $ Map.keys (state ^. files)
 
-mockUploadDir :: Text -> MockContract ()
+mockUploadDir :: forall (w :: Type). Text -> MockContract w ()
 mockUploadDir _ = pure ()
 
-mockQueryChainIndex :: ChainIndexQuery -> MockContract ChainIndexResponse
+mockQueryChainIndex :: forall (w :: Type). ChainIndexQuery -> MockContract w ChainIndexResponse
 mockQueryChainIndex = \case
   DatumFromHash _ ->
     -- pure $ DatumHashResponse Nothing
@@ -401,7 +412,7 @@ mockQueryChainIndex = \case
     -- pure $ RedeemerHashResponse Nothing
     throwError @Text "RedeemerFromHash is unimplemented"
   TxOutFromRef txOutRef -> do
-    state <- get @MockContractState
+    state <- get @(MockContractState w)
     pure $ TxOutRefResponse $ Tx.fromTxOut =<< lookup txOutRef (state ^. utxos)
   TxFromTxId _ ->
     -- pure $ TxIdResponse Nothing
@@ -409,14 +420,14 @@ mockQueryChainIndex = \case
   UtxoSetMembership _ ->
     throwError @Text "UtxoSetMembership is unimplemented"
   UtxoSetAtAddress pageQuery _ -> do
-    state <- get @MockContractState
+    state <- get @(MockContractState w)
     pure $
       UtxoSetAtResponse
         ( state ^. tip
         , pageOf pageQuery (Set.fromList (state ^. utxos ^.. traverse . _1))
         )
   UtxoSetWithCurrency pageQuery _ -> do
-    state <- get @MockContractState
+    state <- get @(MockContractState w)
     pure $
       UtxoSetAtResponse
         ( state ^. tip


### PR DESCRIPTION
Add a simple interpreter for Writer effects.
Writer effects in the fake PAB will immediately be sent via websocket to the client in a NewObservableState message, and will not be stored in the PAB.
Another difference is that `w` in `Writer w` must have ToJSON instace, while the Monoid instance is not needed.
