### PR TITLE
Pick only non-Ada inputs for colalteral

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -75,4 +75,4 @@ jobs:
             dist-newstyle
           key: ${{ runner.os }}-cabal
       - name: Build the full ci derivation
-        run: nix build .#check.x86_64-linux --extra-experimental-features nix-command --extra-experimental-features flakes
+        run: nix build -L .#check.x86_64-linux --extra-experimental-features nix-command --extra-experimental-features flakes

--- a/src/MLabsPAB/PreBalance.hs
+++ b/src/MLabsPAB/PreBalance.hs
@@ -165,7 +165,7 @@ balanceTxIns utxos fees tx = do
 -}
 addTxCollaterals :: Map TxOutRef TxOut -> Tx -> Either Text Tx
 addTxCollaterals utxos tx = do
-  let txIns = mapMaybe (rightToMaybe . txOutToTxIn) $ Map.toList utxos
+  let txIns = mapMaybe (rightToMaybe . txOutToTxIn) $ Map.toList $ filterAdaOnly utxos
   txIn <- findPubKeyTxIn txIns
   pure $ tx {txCollateral = Set.singleton txIn}
   where
@@ -174,6 +174,7 @@ addTxCollaterals utxos tx = do
       x@(TxIn _ Nothing) : _ -> Right x
       _ : xs -> findPubKeyTxIn xs
       _ -> Left "There are no utxos to be used as collateral"
+    filterAdaOnly = Map.filter (isAdaOnly . txOutValue)
 
 -- | We need to balance non ada values, as the cardano-cli is unable to balance them (as of 2021/09/24)
 balanceNonAdaOuts :: PubKeyHash -> Map TxOutRef TxOut -> Tx -> Either Text Tx
@@ -236,3 +237,9 @@ unflattenValue (curSymbol, tokenName, amount) =
 isValueNat :: Value -> Bool
 isValueNat =
   all (\(_, _, a) -> a >= 0) . Value.flattenValue
+
+isAdaOnly :: Value -> Bool
+isAdaOnly v =
+  case Value.flattenValue v of
+    [("", "", _)] -> True
+    _ -> False

--- a/test/Spec/MLabsPAB/Contract.hs
+++ b/test/Spec/MLabsPAB/Contract.hs
@@ -197,14 +197,21 @@ multisigSupport = do
 
 sendTokens :: Assertion
 sendTokens = do
-  let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
-      txOut =
+  let txOutRef1 = TxOutRef "08b27dbdcff9ab3b432638536ec7eab36c8a2e457703fb1b559dd754032ef431" 0
+      txOut1 =
         TxOut
           (Ledger.pubKeyHashAddress pkh1)
           (Ada.lovelaceValueOf 1250 <> Value.singleton "abcd1234" "testToken" 100)
           Nothing
-      initState = def & utxos .~ [(txOutRef, txOut)]
-      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
+      txOutRef2 = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 1
+      txOut2 =
+        TxOut
+          (Ledger.pubKeyHashAddress pkh1)
+          (Ada.lovelaceValueOf 1250)
+          Nothing
+      initState = def & utxos .~ [(txOutRef1, txOut1), (txOutRef2, txOut2)]
+      inTxId1 = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef1
+      inTxId2 = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef2
 
       contract :: Contract () (Endpoint "SendAda" ()) Text CardanoTx
       contract = do
@@ -221,8 +228,8 @@ sendTokens = do
         ( 4
         , [text|
           cardano-cli transaction build --alonzo-era
-          --tx-in ${inTxId}#0
-          --tx-in-collateral ${inTxId}#0
+          --tx-in ${inTxId1}#0
+          --tx-in-collateral ${inTxId2}#1
           --tx-out ${addr1}+50 + 95 abcd1234.testToken
           --tx-out ${addr2}+1000 + 5 abcd1234.testToken
           --required-signer ./signing-keys/signing-key-${pkh1'}.skey
@@ -234,14 +241,21 @@ sendTokens = do
 
 sendTokensWithoutName :: Assertion
 sendTokensWithoutName = do
-  let txOutRef = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 0
-      txOut =
+  let txOutRef1 = TxOutRef "08b27dbdcff9ab3b432638536ec7eab36c8a2e457703fb1b559dd754032ef431" 0
+      txOut1 =
         TxOut
           (Ledger.pubKeyHashAddress pkh1)
           (Ada.lovelaceValueOf 1250 <> Value.singleton "abcd1234" "" 100)
           Nothing
-      initState = def & utxos .~ [(txOutRef, txOut)]
-      inTxId = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef
+      txOutRef2 = TxOutRef "e406b0cf676fc2b1a9edb0617f259ad025c20ea6f0333820aa7cef1bfe7302e5" 1
+      txOut2 =
+        TxOut
+          (Ledger.pubKeyHashAddress pkh1)
+          (Ada.lovelaceValueOf 1250)
+          Nothing
+      initState = def & utxos .~ [(txOutRef1, txOut1), (txOutRef2, txOut2)]
+      inTxId1 = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef1
+      inTxId2 = encodeByteString $ fromBuiltin $ TxId.getTxId $ Tx.txOutRefId txOutRef2
 
       contract :: Contract () (Endpoint "SendAda" ()) Text CardanoTx
       contract = do
@@ -258,8 +272,8 @@ sendTokensWithoutName = do
         ( 4
         , [text|
           cardano-cli transaction build --alonzo-era
-          --tx-in ${inTxId}#0
-          --tx-in-collateral ${inTxId}#0
+          --tx-in ${inTxId1}#0
+          --tx-in-collateral ${inTxId2}#1
           --tx-out ${addr1}+50 + 95 abcd1234
           --tx-out ${addr2}+1000 + 5 abcd1234
           --required-signer ./signing-keys/signing-key-${pkh1'}.skey

--- a/test/Spec/MockContract.hs
+++ b/test/Spec/MockContract.hs
@@ -274,7 +274,7 @@ mockQueryUtxoOut utxos' =
                       Nothing -> "TxOutDatumNone"
                       Just (DatumHash dh) ->
                         "TxDatumHash ScriptDataInAlonzoEra " <> encodeByteString (fromBuiltin dh)
-                 in [text|${txId'}     ${txIx'}        ${amts} + ${datumHash'}"|]
+                 in [text|${txId'}     ${txIx'}        ${amts} + ${datumHash'}|]
             )
             utxos'
       ]


### PR DESCRIPTION
`cardano-cli` will throw an error if input containing `Value` with non-Ada assets will be supplied as collateral. This PR fixes the issue by filtering out utxos which will be invalid for collateral.